### PR TITLE
fix(pkg): storybook instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ this package simply applies a custom theme over semantic-ui, re-exports react-se
 
 - clone this repository
 - run `yarn` from the project directory
-- run `yarn run build` from the /semantic directory
-- `yarn start`
+- run `yarn run build`
+- run `yarn start`
 
 open the url shown to see the latest storybook!
 


### PR DESCRIPTION
Previously had to run `gulp build` from `semantic` dir, now `yarn run build` from project dir executes `gulp build` for us. The readme incorrectly merged the two instructions.

# problem statement

Docs incorrectly had merged the old way of `gulp build` from the `semantic` dir, with the new way of `yarn run build` from the project dir.

# solution

Drop `semantic` dir from storybook startup instructions.

@cdaringe 

Closes #13 