### PR TITLE
fix(fonts): drop dupelicate font ref

### DIFF
--- a/semantic/src/themes/tripwire/elements/icon.variables
+++ b/semantic/src/themes/tripwire/elements/icon.variables
@@ -15,11 +15,6 @@
   url("@{fontPath}/@{fontName}.woff") format('woff'),
   url("@{fontPath}/@{fontName}.ttf") format('truetype'),
   url("@{fontPath}/@{fontName}.svg#icons") format('svg'),
-
-  url("../../node_modules/elegant-icons/fonts/ElegantIcons.woff") format('woff'),
-  url("../../node_modules/elegant-icons/fonts/ElegantIcons.eot") format('embedded-opentype'),
-  url("../../node_modules/elegant-icons/fonts/ElegantIcons.ttf") format('truetype'),
-  url("../../node_modules/elegant-icons/fonts/ElegantIcons.svg#icons") format('svg'),
 ;
 
 @opacity: 1;


### PR DESCRIPTION
# problem statement

- fonts were not resolving

# solution

- drop duplicate font ref.  `elegant` is already in `site.overrides`
