### PR TITLE
Enable relative positioning for Large Card

### DIFF
--- a/src/components/LargeCard/LargeCard.examples.md
+++ b/src/components/LargeCard/LargeCard.examples.md
@@ -1,8 +1,8 @@
 Standard Large Card
      
      const Flexbox = require('flexbox-react').default;
-     <div style={{height: '275px'}}>
-     <LargeCard showCard>
+     <div style={{height: '300px'}}>
+     <LargeCard showCard framed>
         <LargeCard.Gutter color='critical' />
         <LargeCard.Content style={{height: '275px'}}>
           <Flexbox flexDirection='column' flexGrow={1} className='column'>

--- a/src/components/LargeCard/LargeCard.jsx
+++ b/src/components/LargeCard/LargeCard.jsx
@@ -23,15 +23,21 @@ class LargeCard extends React.Component {
 
   render () {
     return (
-      <div className={`large_card  is-fullview-open-${this.props.showCard} ${this.props.className} `} style={this.props.style}>
-        <Flexbox flexDirection='row' className='large_card__container'>
+      <Flexbox className={`large_card  is-fullview-open-${this.props.showCard} ${this.props.className} `} style={this.props.style}>
+        <Flexbox flexDirection='row' flexGrow={3} className={`large_card__container ` + ((this.props.framed) ? 'framed' : '')}>
           {this.props.children}
         </Flexbox>
-      </div>
+      </Flexbox>
     )
   }
 }
-LargeCard.propTypes = {
 
+LargeCard.defaultProps = {
+  className: '',
+  framed: false
+}
+LargeCard.propTypes = {
+  className: React.PropTypes.string,
+  framed: React.PropTypes.bool
 }
 export default LargeCard

--- a/src/styles/components/large-card.css
+++ b/src/styles/components/large-card.css
@@ -8,16 +8,14 @@
   left: 0;
   min-height: 100%;
   opacity: 0;
-  position: absolute;
+  position: relative;
   top: 0;
   transition: opacity 0.4s;
   visibility: hidden;
   width: 100%;
   z-index: 20;
   left: -10000px;
-  -webkit-box-shadow: inset -3px 0px 9px -4px rgba(0,0,0,0.31);
-  -moz-box-shadow: inset -3px 0px 9px -4px rgba(0,0,0,0.31);
-  box-shadow: inset -3px 0px 9px -4px rgba(0,0,0,0.31);
+
   &.is-fullview-open-true {
     opacity: 1;
     visibility: visible;
@@ -37,10 +35,13 @@
 .star_gray{
   color: var(--buttonBorder) !important;
 }
+.framed{
+  margin: 10px 20px 10px 20px;
+}
 .large_card__container {
   background: white;
   clear: fix;
-  margin: 10px 20px 10px 20px;
+  
   min-height: 94%;
   position: relative;
   & .label {


### PR DESCRIPTION
enable relative positioning for large card

# problem statement

The large card component was originally designed to be displayed in absolute position.  This doesn't work if the intended usage changes to want to display multiple Large Card components.

# solution

Enable relative positioning.  This can be overridden by setting a style of position absolute whenever necessary.  Additionally the card was designed with a inset frame style display, this adds a flag which can enable/disable that framed display.  

# discussion

Framed
![image](https://cloud.githubusercontent.com/assets/1723648/24181089/0d528b20-0e76-11e7-9352-7d85e347d333.png)



Not Framed
![image](https://cloud.githubusercontent.com/assets/1723648/24181100/2527f744-0e76-11e7-88e8-06c7851a5c29.png)
