### PR TITLE
feat(LargeCard): add title property

### DIFF
--- a/src/components/LargeCard/LargeCardTitle.jsx
+++ b/src/components/LargeCard/LargeCardTitle.jsx
@@ -4,8 +4,8 @@ import Flexbox from 'flexbox-react'
 const LargeCardTitle = (props) => {
   return (
     <Flexbox flexGrow={3} flexDirection='column'>
-      <div className='title'>{props.title}</div>
-      <div className='text-small textGray'>{props.description}</div>
+      <div title={props.title} className='title'>{props.title}</div>
+      <div title={props.description} className='text-small textGray'>{props.description}</div>
     </Flexbox>
   )
 }


### PR DESCRIPTION
# problem statement

We needed LargeCard.Title divs for card title and description fields to have hover text, so that we can truncate long strings in display, but end user can still see full value on hover.

# solution

Add 'title' attribute to card title and description divs

# discussion
