### PR TITLE
feat(util): allow custom attributes on components

### DIFF
--- a/src/components/LargeCard/LargeCard.examples.md
+++ b/src/components/LargeCard/LargeCard.examples.md
@@ -1,5 +1,5 @@
 Standard Large Card
-     
+
      const Flexbox = require('flexbox-react').default;
      <div style={{height: '300px'}}>
      <LargeCard showCard framed>
@@ -17,9 +17,9 @@ Standard Large Card
           </Flexbox>
           <Flexbox flexDirection='column' flexGrow={3}>
             <Flexbox flexDirection='row' marginBottom="35px">
-              <LargeCard.KeyValue name='item' value={29} />
-              <LargeCard.KeyValue name='item' value={29} />
-              <LargeCard.KeyValue name='item' value={29} />
+              <LargeCard.KeyValue label='item1' value={29} data-hook='item1' />
+              <LargeCard.KeyValue label='item2' value={30} />
+              <LargeCard.KeyValue label='item3' value={31} />
             </Flexbox>
             <LargeCard.RecentList items={[
             {

--- a/src/components/LargeCard/LargeCardKeyValue.jsx
+++ b/src/components/LargeCard/LargeCardKeyValue.jsx
@@ -1,9 +1,11 @@
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import React from 'react'
 
 const LargeCardKeyValue = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <div className={`summary_info ${props.className}`} onClick={props.onClick}>
-      <span className='label'>{props.name}</span>
+    <div {...externalAttributes} className={`summary_info ${props.className}`}>
+      <span className='label'>{props.label}</span>
       <span className='count'>{props.value}</span>
     </div>
   )

--- a/src/util/externalAttributeFilter.js
+++ b/src/util/externalAttributeFilter.js
@@ -1,0 +1,24 @@
+import isEmpty from 'lodash/isEmpty'
+import isString from 'lodash/isString'
+import pickBy from 'lodash/pickBy'
+import some from 'lodash/some'
+
+const allowedExternalAttributes = [
+  'aria-*',
+  'className',
+  'data-*',
+  'id',
+  'name',
+  'on*'
+]
+
+export default function filterAttributesFromProps (props) {
+  return pickBy(props, (propValue, propName) => {
+    if (!isString(propValue) || isEmpty(propValue)) {
+      return false
+    }
+    return some(allowedExternalAttributes, (allowedAttributeName) => {
+      return propName.match(allowedAttributeName)
+    })
+  })
+}

--- a/src/util/externalAttributeFilter.js
+++ b/src/util/externalAttributeFilter.js
@@ -1,5 +1,3 @@
-import isEmpty from 'lodash/isEmpty'
-import isString from 'lodash/isString'
 import pickBy from 'lodash/pickBy'
 import some from 'lodash/some'
 
@@ -14,9 +12,6 @@ const allowedExternalAttributes = [
 
 export default function filterAttributesFromProps (props) {
   return pickBy(props, (propValue, propName) => {
-    if (!isString(propValue) || isEmpty(propValue)) {
-      return false
-    }
     return some(allowedExternalAttributes, (allowedAttributeName) => {
       return propName.match(allowedAttributeName)
     })


### PR DESCRIPTION
# problem statement

Users desire to use attributes such as `data-hook` on our components.

# solution

Starting with a somewhat small list of desired attributes, filter the props and apply them to the top-level element in the component. This change starts with LargeCardKeyValue, and will need to be applied to the other components.

BREAKING CHANGE: In LargeCardKeyValue, the `name` attribute has been changed to `label`, so that the top-level element in the component can support an arbitrary `name` attribute, and not conflict.

# discussion

If this seems reasonable, I will then apply the same change to the rest of the components.