### PR TITLE
fix(LargeCard): use external attributes

### DIFF
--- a/src/components/LargeCard/LargeCard.examples.md
+++ b/src/components/LargeCard/LargeCard.examples.md
@@ -12,7 +12,7 @@ Standard Large Card
             </Flexbox>
             <Flexbox flexDirection="column">
                 Place left column content here
-                <LargeCard.Stat name='assets' value={294} />
+                <LargeCard.Stat label='assets' value={294} />
             </Flexbox>
           </Flexbox>
           <Flexbox flexDirection='column' flexGrow={3}>

--- a/src/components/LargeCard/LargeCard.jsx
+++ b/src/components/LargeCard/LargeCard.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
+import '../../styles/components/large-card.css'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import LargeCardAction from './LargeCardAction'
 import LargeCardClose from './LargeCardClose'
-import LargeCardGutter from './LargeCardGutter'
 import LargeCardContent from './LargeCardContent'
+import LargeCardGutter from './LargeCardGutter'
 import LargeCardKeyValue from './LargeCardKeyValue'
 import LargeCardRecentList from './LargeCardRecentList'
-import LargeCardTitle from './LargeCardTitle'
 import LargeCardStat from './LargeCardStat'
-
-import '../../styles/components/large-card.css'
+import LargeCardTitle from './LargeCardTitle'
 
 class LargeCard extends React.Component {
   static Action = LargeCardAction;
@@ -22,9 +22,16 @@ class LargeCard extends React.Component {
   static Stat = LargeCardStat;
 
   render () {
+    const externalAttributes = filterAttributesFromProps(this.props)
     return (
-      <Flexbox className={`large_card  is-fullview-open-${this.props.showCard} ${this.props.className} `} style={this.props.style}>
-        <Flexbox flexDirection='row' flexGrow={3} className={`large_card__container ` + ((this.props.framed) ? 'framed' : '')}>
+      <Flexbox
+        {...externalAttributes}
+        className={`large_card is-fullview-open-${this.props.showCard} ${this.props.className}`}
+        style={this.props.style}>
+        <Flexbox
+          flexDirection='row'
+          flexGrow={3}
+          className={`large_card__container ` + ((this.props.framed) ? 'framed' : '')}>
           {this.props.children}
         </Flexbox>
       </Flexbox>

--- a/src/components/LargeCard/LargeCardAction.jsx
+++ b/src/components/LargeCard/LargeCardAction.jsx
@@ -1,9 +1,15 @@
 import React from 'react'
 import Button from '../suir/button/Button'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardAction = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Button className='tripwire fullview__goto__button' onClick={props.onClick}>{props.label}</Button>
+    <Button
+      {...externalAttributes}
+      className={`tripwire fullview__goto__button ${props.className}`}>
+      {props.label}
+    </Button>
   )
 }
 

--- a/src/components/LargeCard/LargeCardClose.jsx
+++ b/src/components/LargeCard/LargeCardClose.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import Icon from '../suir/icon/Icon'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardClose = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <span className='close__fullview' onClick={props.onClick}>
+    <span {...externalAttributes} className={`close__fullview ${props.className}`}>
       <Icon className='ei icon_close' aria-hidden='true' />
     </span>
   )

--- a/src/components/LargeCard/LargeCardContent.jsx
+++ b/src/components/LargeCard/LargeCardContent.jsx
@@ -1,9 +1,19 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardContent = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox flexDirection='row' flexGrow={3} className={` ${props.className}`} style={props.style} paddingTop='10px' paddingBottom='10px' paddingLeft='15px' paddingRight='15px'>
+    <Flexbox
+      {...externalAttributes}
+      flexDirection='row'
+      flexGrow={3}
+      style={props.style}
+      paddingTop='10px'
+      paddingBottom='10px'
+      paddingLeft='15px'
+      paddingRight='15px'>
       {props.children}
     </Flexbox>
   )

--- a/src/components/LargeCard/LargeCardGutter.jsx
+++ b/src/components/LargeCard/LargeCardGutter.jsx
@@ -1,8 +1,10 @@
+import Flexbox from 'flexbox-react'
 import React from 'react'
 import palette from '../../palette'
-import Flexbox from 'flexbox-react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardGutter = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   let color = ''
   switch (props.color) {
     case 'critical':
@@ -21,7 +23,11 @@ const LargeCardGutter = (props) => {
       color = props.color
   }
   return (
-    <Flexbox className='fullview__left_border' width='9px' style={{ backgroundColor: color }} />
+    <Flexbox
+      {...externalAttributes}
+      className={`fullview__left_border ${props.className}`}
+      width='9px'
+      style={{ backgroundColor: color }} />
   )
 }
 

--- a/src/components/LargeCard/LargeCardKeyValue.jsx
+++ b/src/components/LargeCard/LargeCardKeyValue.jsx
@@ -1,5 +1,5 @@
-import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardKeyValue = (props) => {
   const externalAttributes = filterAttributesFromProps(props)

--- a/src/components/LargeCard/LargeCardRecentList.jsx
+++ b/src/components/LargeCard/LargeCardRecentList.jsx
@@ -1,10 +1,15 @@
+import Flexbox from 'flexbox-react'
 import React from 'react'
 import Icon from '../suir/icon/Icon'
-import Flexbox from 'flexbox-react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardRecentList = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox flexDirection='column' flexGrow={1} className={props.className}>
+    <Flexbox
+      {...externalAttributes}
+      flexDirection='column'
+      flexGrow={1}>
 
       <h4 className='label'>Recent</h4>
       {props.items.map((item) => {

--- a/src/components/LargeCard/LargeCardStat.jsx
+++ b/src/components/LargeCard/LargeCardStat.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardStat = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox className={`stats ${props.className}`} flexDirection='row'>
-      <span className='label'>{props.name}</span>
+    <Flexbox {...externalAttributes} className={`stats ${props.className}`} flexDirection='row'>
+      <span className='label'>{props.label}</span>
       <span className='value'>{props.value}</span>
     </Flexbox>
   )
@@ -16,7 +18,7 @@ LargeCardStat.defaultProps = {
 }
 
 LargeCardStat.propTypes = {
-  name: React.PropTypes.string,
+  label: React.PropTypes.string,
   value: React.PropTypes.number
 }
 

--- a/src/components/LargeCard/LargeCardTitle.jsx
+++ b/src/components/LargeCard/LargeCardTitle.jsx
@@ -1,9 +1,11 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const LargeCardTitle = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox flexGrow={3} flexDirection='column'>
+    <Flexbox {...externalAttributes} flexGrow={3} flexDirection='column'>
       <div title={props.title} className='title'>{props.title}</div>
       <div title={props.description} className='text-small textGray'>{props.description}</div>
     </Flexbox>


### PR DESCRIPTION
# problem statement

Since the external attributes are working on `LargeCardKeyValue`, apply it to the rest of the `LargeCard` classes.

# solution

Apply the pattern!

BREAKING CHANGE: `LargeCard.Stat` had the `name` prop changed to `label`.

# discussion

No visual changes. I smoke tested each component on the fly by adding `data-hook` through styleguidist.

This is another step towards addressing #57.