### PR TITLE
fix(AreaChart, BarChart, Circle): use external attributes

### DIFF
--- a/src/components/charts/AreaChart/AreaChart.jsx
+++ b/src/components/charts/AreaChart/AreaChart.jsx
@@ -5,6 +5,7 @@ import ToolTip from './ToolTip'
 import Dots from '../Chart/Dots'
 import ChartOverlay from '../Chart/ChartOverlay'
 import * as ChartUtils from '../Chart/utils'
+import filterAttributesFromProps from '../../../util/externalAttributeFilter'
 
 var d3 = Object.assign({}, require('d3-shape'), require('d3-format'), require('d3-axis'))
 
@@ -136,8 +137,9 @@ class AreaChart extends React.Component {
       .scale(yScale)
       .ticks(5)
 
+    const externalAttributes = filterAttributesFromProps(this.props)
     return (
-      <div className='area__chart__container'>
+      <div {...externalAttributes} className={`area-chart__container ${this.props.className}`}>
         <svg width={width} height={innerHeight}>
           <g transform='translate(2, 4)'>
             <PlotArea

--- a/src/components/charts/BarChart/BarChart.jsx
+++ b/src/components/charts/BarChart/BarChart.jsx
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react'
 import Rect from './Rect'
 import ToolTip from './BarChartTooltip'
 import * as ChartUtils from '../Chart/utils'
+import filterAttributesFromProps from '../../../util/externalAttributeFilter'
+
 var d3 = Object.assign({}, require('d3-time-format'), require('d3-axis'))
 const { array, number, object, string, bool } = PropTypes
 class BarChart extends React.Component {
@@ -72,8 +74,9 @@ class BarChart extends React.Component {
 
     const yScale = ChartUtils.yScaleLinear(data, innerHeight, 0)
 
+    const externalAttributes = filterAttributesFromProps(this.props)
     return (
-      <div className='bar-chart__container svg-overflow-visible'>
+      <div {...externalAttributes} className={`bar-chart__container svg-overflow-visible ${this.props.className}`}>
         <svg width={width} height={height}>
           <g transform={transform}>
             <Rect

--- a/src/components/charts/CircleChart/Circle.jsx
+++ b/src/components/charts/CircleChart/Circle.jsx
@@ -22,24 +22,24 @@ const CircleChart = (props) => {
             .outerRadius(radius - 1)
   const externalAttributes = filterAttributesFromProps(props)
   return (
-    <div>
+    <div {...externalAttributes} >
       <svg width={boxSize} height={boxSize}>
         <g transform='translate(55,55)'>
-          <g {...externalAttributes} className={`progress-meter ${props.className}`}>
+          <g className='progress-meter'>
             <path
-              {...externalAttributes} className={`background ${props.className}`}
+              className='background'
               fill='#8faec1'
               fillOpacity={backgroundOpacity}
               d={arcbg.endAngle(twoPi)()}
             />
             <path
-              {...externalAttributes} className={`foreground ${props.className}`}
+              className='foreground'
               fill={color}
               fillOpacity='1'
               d={arc.endAngle(twoPi * endPercent)()}
             />
             <text
-              {...externalAttributes} className={`current-progress ${props.className}`}
+              className='current-progress'
               fill={color}
               textAnchor='middle'
               dy='.35em'

--- a/src/components/charts/CircleChart/Circle.jsx
+++ b/src/components/charts/CircleChart/Circle.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import palette from '../../../palette'
+import filterAttributesFromProps from '../../../util/externalAttributeFilter'
+
 var d3 = Object.assign({}, require('d3-shape'))
 
 const twoPi = Math.PI * 2
@@ -18,25 +20,26 @@ const CircleChart = (props) => {
             .startAngle(0)
             .innerRadius(radius - 4)
             .outerRadius(radius - 1)
+  const externalAttributes = filterAttributesFromProps(props)
   return (
     <div>
       <svg width={boxSize} height={boxSize}>
         <g transform='translate(55,55)'>
-          <g className='progress-meter'>
+          <g {...externalAttributes} className={`progress-meter ${props.className}`}>
             <path
-              className='background'
+              {...externalAttributes} className={`background ${props.className}`}
               fill='#8faec1'
               fillOpacity={backgroundOpacity}
               d={arcbg.endAngle(twoPi)()}
             />
             <path
-              className='foreground'
+              {...externalAttributes} className={`foreground ${props.className}`}
               fill={color}
               fillOpacity='1'
               d={arc.endAngle(twoPi * endPercent)()}
             />
             <text
-              className='current-progress'
+              {...externalAttributes} className={`current-progress ${props.className}`}
               fill={color}
               textAnchor='middle'
               dy='.35em'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,10 +1262,6 @@ bluebird@^3.4.1, bluebird@^3.4.6, bluebird@^3.4.7, bluebird@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-bluebird@~3.4.6:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
-
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -1492,12 +1488,6 @@ caseless@~0.11.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-catharsis@~0.8.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.8.tgz#693479f43aac549d806bd73e924cd0d944951a06"
-  dependencies:
-    underscore-contrib "~0.3.0"
 
 ccount@^1.0.0:
   version "1.0.1"
@@ -1969,27 +1959,27 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-counsel-precommit@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/counsel-precommit/-/counsel-precommit-0.0.29.tgz#31cce9144a6249c63d8e2c4b26aa91e037152674"
+counsel-precommit@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/counsel-precommit/-/counsel-precommit-0.1.4.tgz#60d310449a37253e88245e138944d85af2a6bab4"
   dependencies:
-    counsel-rule "^0.0.29"
+    counsel-rule "^0.1.4"
 
-counsel-rule@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/counsel-rule/-/counsel-rule-0.0.29.tgz#ce0a8d45701ad03794ca4bd2c5e9f32697762205"
+counsel-rule@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/counsel-rule/-/counsel-rule-0.1.4.tgz#19d3231686b750dc57fdc90d899a46981ece1952"
 
-counsel-script@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/counsel-script/-/counsel-script-0.0.29.tgz#f7bd9a5d408089d3fbe731479792072169237503"
+counsel-script@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/counsel-script/-/counsel-script-0.1.4.tgz#fa99c514fbb43d489a34f4a848b9479c314b9d62"
   dependencies:
-    counsel-rule "^0.0.29"
+    counsel-rule "^0.1.4"
 
-counsel@0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/counsel/-/counsel-0.0.29.tgz#bf90748dc878844e4f59f35814681a38fe54faf4"
+counsel@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/counsel/-/counsel-0.1.4.tgz#8dededdd70f69d6fc09b0187b871eda940972792"
   dependencies:
-    counsel-rule "^0.0.29"
+    counsel-rule "^0.1.4"
     lodash.clonedeep "^4.5.0"
     lodash.uniq "^4.5.0"
     winston "^2.2.0"
@@ -2017,13 +2007,13 @@ cross-spawn-async@^2.1.1:
     lru-cache "^4.0.0"
     which "^1.2.8"
 
-cross-spawn-promise@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn-promise/-/cross-spawn-promise-0.9.2.tgz#92ef7cfbf39ae06e89bb3be73af6eb2d8f47f4c1"
+cross-spawn-promise@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn-promise/-/cross-spawn-promise-0.10.1.tgz#db9cb4c50c60b72a15be049b78122ce382d87b10"
   dependencies:
-    cross-spawn "^5.0.1"
+    cross-spawn "^5.1.0"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -2847,7 +2837,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2939,13 +2929,6 @@ espree@^3.4.0:
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
   dependencies:
     acorn "4.0.4"
-    acorn-jsx "^3.0.0"
-
-espree@~3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.1.7.tgz#fd5deec76a97a5120a9cd3a7cb1177a0923b11d2"
-  dependencies:
-    acorn "^3.3.0"
     acorn-jsx "^3.0.0"
 
 esprima@^2.1.0, esprima@^2.6.0, esprima@^2.7.1, esprima@~2.7.1:
@@ -5162,30 +5145,9 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js2xmlparser@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-1.0.0.tgz#5a170f2e8d6476ce45405e04823242513782fe30"
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
-jsdoc@^3.4.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.4.3.tgz#e5740d6145c681f6679e6c17783a88dbdd97ccd3"
-  dependencies:
-    bluebird "~3.4.6"
-    catharsis "~0.8.8"
-    escape-string-regexp "~1.0.5"
-    espree "~3.1.7"
-    js2xmlparser "~1.0.0"
-    klaw "~1.3.0"
-    marked "~0.3.6"
-    mkdirp "~0.5.1"
-    requizzle "~0.2.1"
-    strip-json-comments "~2.0.1"
-    taffydb "2.6.2"
-    underscore "~1.8.3"
 
 jsdom@^9.11.0:
   version "9.11.0"
@@ -5342,7 +5304,7 @@ kind-of@^3.0.2:
   dependencies:
     is-buffer "^1.0.2"
 
-klaw@^1.0.0, klaw@~1.3.0:
+klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   optionalDependencies:
@@ -6013,7 +5975,7 @@ marked-terminal@^1.6.2:
     lodash.assign "^4.2.0"
     node-emoji "^1.4.1"
 
-marked@^0.3.6, marked@~0.3.6:
+marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
@@ -6122,10 +6084,6 @@ mimeparse@^0.1.4:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
-
-minami@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/minami/-/minami-1.1.1.tgz#11e33c46f5fff6d391085e17df9a5e4a761f9dfc"
 
 "minimatch@2 || 3", minimatch@3.0.3, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
@@ -8393,7 +8351,7 @@ request-promise@^4.1.1:
     request-promise-core "1.1.1"
     stealthy-require "^1.0.0"
 
-request@2, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.79.0, request@~2.81.0:
+request@2, request@^2.72.0, request@^2.74.0, request@^2.75.0, request@^2.78.0, request@^2.79.0, request@~2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -8420,7 +8378,7 @@ request@2, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.79.0, r
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@2.79.0, request@^2.58.0, request@^2.75.0:
+request@2.79.0, request@^2.58.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -8502,12 +8460,6 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-requizzle@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
-  dependencies:
-    underscore "~1.6.0"
-
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
@@ -8518,10 +8470,6 @@ resolve-dir@^0.1.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
-resolve-jsdoc-bin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-jsdoc-bin/-/resolve-jsdoc-bin-1.0.0.tgz#6b1119539aa006548516fb8aab5651a523ce7dd9"
 
 resolve-url@~0.2.1:
   version "0.2.1"
@@ -8613,23 +8561,20 @@ rimraf@~2.5.1, rimraf@~2.5.4:
   dependencies:
     glob "^7.0.5"
 
-ripcord@^0.25.5:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/ripcord/-/ripcord-0.25.7.tgz#5fac63a5af314f225ced74985989df30f482aa36"
+ripcord@^1.1.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ripcord/-/ripcord-1.2.4.tgz#21d62057fd11895e562dd0ea852092be33c36ece"
   dependencies:
     bluebird "^3.4.6"
     chalk "^1.1.3"
     commander "^2.9.0"
     commander-pojo "^1.0.1"
-    counsel "0.0.29"
-    counsel-precommit "^0.0.29"
-    counsel-script "^0.0.29"
-    gh-pages "^0.12.0"
-    jsdoc "^3.4.2"
+    counsel "^0.1.4"
+    counsel-precommit "^0.1.4"
+    counsel-script "^0.1.4"
     json2csv "^3.7.1"
     license-checker "^8.0.0"
     lodash "^4.17.2"
-    minami "^1.1.1"
     npm "^4.3.0"
     parse-name-at-version "^1.0.0"
     parse-yarn-lock "^1.0.2"
@@ -8637,7 +8582,6 @@ ripcord@^0.25.5:
     pify "^2.3.0"
     read-pkg-up "^2.0.0"
     request "^2.75.0"
-    resolve-jsdoc-bin "^1.0.0"
     snyk-resolve-deps "^1.8.0"
 
 ripemd160@0.2.0:
@@ -9436,10 +9380,6 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-taffydb@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
-
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
@@ -9755,12 +9695,6 @@ unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-underscore-contrib@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
-  dependencies:
-    underscore "1.6.0"
-
 underscore.string@~2.2.0rc:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19"
@@ -9769,17 +9703,9 @@ underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
 
-underscore@1.6.0, underscore@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
-
 underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-
-underscore@~1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION


# problem statement

We can't currently expand our UI automation until external attributes are
permitted in some of our react components.

# solution

Apply pattern used on `LargeCardKeyValue` to AreaChart, BarChart, and Circle
to allow data-hooks to be added to facilitate the addition of automated tests.

# discussion

No visual changes. I smoke tested each component on the fly by adding data-hook through styleguidist.

<!--
// here's a handy bash function to load into your shell profile so you can convert
// screen recordings to animated GIFs!
// movToGif my-screen-recording.mov ==> my-screen-recording.mov.gif
function movToGif() {
  `ffmpeg -i $1 -pix_fmt rgb24 -r 5 -f gif - | gifsicle --optimize=4 --delay=20 > $1.gif`;
}
-->
