### PR TITLE
fix(props): unknown prop warnings

### DIFF
--- a/src/components/LargeCard/LargeCard.jsx
+++ b/src/components/LargeCard/LargeCard.jsx
@@ -41,10 +41,12 @@ class LargeCard extends React.Component {
 
 LargeCard.defaultProps = {
   className: '',
-  framed: false
+  framed: false,
+  showCard: false
 }
 LargeCard.propTypes = {
   className: React.PropTypes.string,
-  framed: React.PropTypes.bool
+  framed: React.PropTypes.bool,
+  showCard: React.PropTypes.bool
 }
 export default LargeCard

--- a/src/util/externalAttributeFilter.js
+++ b/src/util/externalAttributeFilter.js
@@ -2,12 +2,12 @@ import pickBy from 'lodash/pickBy'
 import some from 'lodash/some'
 
 const allowedExternalAttributes = [
-  'aria-*',
-  'className',
-  'data-*',
-  'id',
-  'name',
-  'on*'
+  /^aria-.*$/,
+  /^className$/,
+  /^data-.*$/,
+  /^id$/,
+  /^name$/,
+  /^on.*$/
 ]
 
 export default function filterAttributesFromProps (props) {


### PR DESCRIPTION
# problem statement

The externalAttributeFilter regexes were too broad, and `on*` matched `description` for example.

# solution

Add needed line anchors to only match the intended prop names.

# discussion

We should really bite the bullet and just start using Jest tests or anything really. Or I should have paid attention to the warnings in the browser console.