### PR TITLE
fix(ThinCard): use external attributes

### DIFF
--- a/src/components/ThinCard/ThinCard.jsx
+++ b/src/components/ThinCard/ThinCard.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-
+import '../../styles/components/thin-card.css'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import ThinCardTitle from './ThinCardTitle'
 import ThinCardPrimaryAction from './ThinCardPrimaryAction'
 import ThinCardActionButton from './ThinCardActionButton'
 import ThinCardWidget from './ThinCardWidget'
 import ThinCardDrawer from './ThinCardDrawer'
-import '../../styles/components/thin-card.css'
 
 class ThinCard extends React.Component {
   static Title = ThinCardTitle
@@ -23,8 +23,13 @@ class ThinCard extends React.Component {
     if (this.props.folder) {
       borderClass += ' thincard__folderpad'
     }
+    const externalAttributes = filterAttributesFromProps(this.props)
     return (
-      <Flexbox flexDirection='column' className={`thincard__row ${borderClass}`} key={this.props.data.id}>
+      <Flexbox
+        {...externalAttributes}
+        flexDirection='column'
+        className={`thincard__row ${borderClass} ${this.props.className}`}
+        key={this.props.data.id}>
 
         {(this.props.folder) ? (
           <div className='topedge' />

--- a/src/components/ThinCard/ThinCardActionButton.jsx
+++ b/src/components/ThinCard/ThinCardActionButton.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const ThinCardActionButton = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox alignItems='center' flexGrow={3}>
-      <div onClick={props.onClick} className={`thincard__action_button ${props.ClassName}`} style={props.style}>
+    <Flexbox {...externalAttributes} alignItems='center' flexGrow={3}>
+      <div className={`thincard__action_button ${props.innerDivClassName}`} style={props.style}>
         {props.children}
       </div>
     </Flexbox>
@@ -13,13 +15,12 @@ const ThinCardActionButton = (props) => {
 
 ThinCardActionButton.defaultProps = {
   style: {},
-  className: {}
+  innerDivClassName: {}
 }
 
 ThinCardActionButton.propTypes = {
   style: React.PropTypes.object,
-  className: React.PropTypes.object,
-  onClick: React.PropTypes.func
+  innerDivClassName: React.PropTypes.object
 }
 
 export default ThinCardActionButton

--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -1,11 +1,12 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import Icon from '../suir/icon/Icon'
 
 const ThinCardDrawer = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <div>
-
+    <div {...externalAttributes}>
       {(!props.expanded) ? (
         <Flexbox className='drawer' flexDirection='row' onClick={props.expandGroupToggle}>
           <Flexbox className='drawer__side' flexGrow={3} />
@@ -38,7 +39,6 @@ ThinCardDrawer.defaultProps = {
 }
 ThinCardDrawer.propTypes = {
   expanded: React.PropTypes.bool,
-  onClick: React.PropTypes.func
-
+  expandGroupToggle: React.PropTypes.func
 }
 export default ThinCardDrawer

--- a/src/components/ThinCard/ThinCardPrimaryAction.jsx
+++ b/src/components/ThinCard/ThinCardPrimaryAction.jsx
@@ -1,9 +1,15 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const ThinCardPrimaryAction = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox alignItems='center' className={`thincard__primary_action ${props.className}`} style={props.style}>
+    <Flexbox
+      {...externalAttributes}
+      alignItems='center'
+      className={`thincard__primary_action ${props.className}`}
+      style={props.style}>
       {props.children}
     </Flexbox>
   )

--- a/src/components/ThinCard/ThinCardTitle.jsx
+++ b/src/components/ThinCard/ThinCardTitle.jsx
@@ -1,9 +1,15 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const ThinCardTitle = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox alignItems='center' className={`thincard__title ${props.className}`} style={props.style}>
+    <Flexbox
+      {...externalAttributes}
+      alignItems='center'
+      className={`thincard__title ${props.className}`}
+      style={props.style}>
       {props.children}
     </Flexbox>
   )

--- a/src/components/ThinCard/ThinCardWidget.jsx
+++ b/src/components/ThinCard/ThinCardWidget.jsx
@@ -1,5 +1,6 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import ThinCardWidgetLabel from './ThinCardWidgetLabel'
 import ThinCardWidgetValue from './ThinCardWidgetValue'
 
@@ -16,8 +17,17 @@ class ThinCardWidget extends React.Component {
       borderClass += 'borderRight '
     }
 
+    const externalAttributes = filterAttributesFromProps(this.props)
     return (
-      <Flexbox onClick={this.props.onClick} alignItems='center' className={` ${borderClass} ${this.props.className}`} paddingRight='15px' paddingLeft='15px' marginBottom='10px' marginTop='10px'>
+      <Flexbox
+        {...externalAttributes}
+        onClick={this.props.onClick}
+        alignItems='center'
+        className={`${borderClass} ${this.props.className}`}
+        paddingRight='15px'
+        paddingLeft='15px'
+        marginBottom='10px'
+        marginTop='10px'>
         {this.props.children}
       </Flexbox>
     )

--- a/src/components/ThinCard/ThinCardWidgetLabel.jsx
+++ b/src/components/ThinCard/ThinCardWidgetLabel.jsx
@@ -1,9 +1,15 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const ThinCardWidgetLabel = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox alignItems='center' className={` ${props.className} thincard__widget_label`} style={props.style}>
+    <Flexbox
+      {...externalAttributes}
+      alignItems='center'
+      className={`${props.className} thincard__widget_label`}
+      style={props.style}>
       {props.children}
     </Flexbox>
   )

--- a/src/components/ThinCard/ThinCardWidgetValue.jsx
+++ b/src/components/ThinCard/ThinCardWidgetValue.jsx
@@ -1,9 +1,15 @@
-import React from 'react'
 import Flexbox from 'flexbox-react'
+import React from 'react'
+import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
 const ThinCardWidgetValue = (props) => {
+  const externalAttributes = filterAttributesFromProps(props)
   return (
-    <Flexbox alignItems='center' className={` ${props.className} thincard__widget_value`} style={props.style}>
+    <Flexbox
+      {...externalAttributes}
+      alignItems='center'
+      className={`${props.className} thincard__widget_value`}
+      style={props.style}>
       {props.children}
     </Flexbox>
   )


### PR DESCRIPTION
# problem statement

ThinCard needs external attributes like `data-hook=*`.

# solution

Apply the external attributes to all ThinCard components.

# discussion

Continued changes to address #57.