### PR TITLE
fix(BarChart): relative icon positioning

### DIFF
--- a/src/components/charts/BarChart/BarChart.examples.md
+++ b/src/components/charts/BarChart/BarChart.examples.md
@@ -1,10 +1,20 @@
-Standard Area AreaChart
+Standard BarChart
 
     <div style={{marginTop: "85px"}}>
     <BarChart
        barPadding={0.3}
        borderRadius={0}
-       data={[ { x: '12-10-2016 01:02:00', y: 40, currentState: 'normal' }, { x: '12-11-2016 03:15:00', y: 50, currentState: 'normal' }, { x: '12-12-2016 05:22:00', y: 65, currentState: 'normal' }, { x: '12-13-2016 05:22:00', y: 60, currentState: 'normal' }, { x: '12-14-2016 05:22:00', y: 70, currentState: 'normal' }, { x: '12-15-2016 05:22:00', y: 55, currentState: 'normal' }, { x: '12-16-2016 05:22:00', y: 80, currentState: 'warning' }, { x: '12-17-2016 05:22:00', y: 55, currentState: 'normal' }, { x: '12-18-2016 05:22:00', y: 75, currentState: 'critical' }, { x: '12-19-2016 05:22:00', y: 50, currentState: 'normal' } ]}
+       data={[ 
+        { x: '12-10-2016 01:02:00', y: 2, currentState: 'warning' }, 
+        { x: '12-11-2016 03:15:00', y: 5, currentState: 'warning' }, 
+        { x: '12-12-2016 05:22:00', y: 10, currentState: 'warning' }, 
+        { x: '12-13-2016 05:22:00', y: 15, currentState: 'warning' }, 
+        { x: '12-14-2016 05:22:00', y: 20, currentState: 'warning' }, 
+        { x: '12-15-2016 05:22:00', y: 25, currentState: 'warning' }, 
+        { x: '12-16-2016 05:22:00', y: 30, currentState: 'warning' }, 
+        { x: '12-17-2016 05:22:00', y: 55, currentState: 'warning' }, 
+        { x: '12-18-2016 05:22:00', y: 75, currentState: 'critical' }, 
+        { x: '12-19-2016 05:22:00', y: 50, currentState: 'normal' } ]}
        height={120}
        width={500}
        xDataType='date'
@@ -22,14 +32,14 @@ Sample data series:
 
 ```javascript
 [
-  { x: '12-10-2016 01:02:00', y: 40, currentState: 'normal' },
-  { x: '12-11-2016 03:15:00', y: 50, currentState: 'normal' },
-  { x: '12-12-2016 05:22:00', y: 65, currentState: 'normal' },
-  { x: '12-13-2016 05:22:00', y: 60, currentState: 'normal' },
-  { x: '12-14-2016 05:22:00', y: 70, currentState: 'normal' },
-  { x: '12-15-2016 05:22:00', y: 55, currentState: 'normal' },
-  { x: '12-16-2016 05:22:00', y: 80, currentState: 'warning' },
-  { x: '12-17-2016 05:22:00', y: 55, currentState: 'normal' },
+  { x: '12-10-2016 01:02:00', y: 2, currentState: 'warning' },
+  { x: '12-11-2016 03:15:00', y: 5, currentState: 'warning' },
+  { x: '12-12-2016 05:22:00', y: 10, currentState: 'warning' },
+  { x: '12-13-2016 05:22:00', y: 15, currentState: 'warning' },
+  { x: '12-14-2016 05:22:00', y: 20, currentState: 'warning' },
+  { x: '12-15-2016 05:22:00', y: 25, currentState: 'warning' },
+  { x: '12-16-2016 05:22:00', y: 30, currentState: 'warning' },
+  { x: '12-17-2016 05:22:00', y: 55, currentState: 'warning' },
   { x: '12-18-2016 05:22:00', y: 75, currentState: 'critical' },
   { x: '12-19-2016 05:22:00', y: 50, currentState: 'normal' }
 ]

--- a/src/components/charts/BarChart/BarChart.jsx
+++ b/src/components/charts/BarChart/BarChart.jsx
@@ -35,8 +35,8 @@ class BarChart extends React.Component {
           value: e.target.getAttribute('data-value')
         },
         pos: {
-          x: e.target.getAttribute('cx'),
-          y: e.target.getAttribute('cy')
+          x: e.target.getAttribute('data-tooltip-x'),
+          y: e.target.getAttribute('data-tooltip-y')
         }
       }
     })

--- a/src/components/charts/BarChart/Rect.jsx
+++ b/src/components/charts/BarChart/Rect.jsx
@@ -26,65 +26,70 @@ const Rect = (props) => {
       fillColor = palette.red
       iconUri = criticalIconUri
     }
+
+    const filledInRectangleHeight = innerHeight - yScale(d.y)
+    let iconY = innerHeight / 1.5
+    if (yScale(d.y) > 83) {
+      iconY = yScale(d.y) - 8 - 25
+    }
+
     return (
-      <g
-        key={`${i}-g`}
-        onMouseEnter={props.showToolTip}
-        onMouseOut={props.hideToolTip}
-      >
+      <g key={`${i}-g`}>
 
         <rect
-          className='shadow'
-          fill={fillColor}
-          height={innerHeight - yScale(d.y)}
-          data-tooltip-pos={innerHeight - yScale(d.y)}
-          key={i}
-          cx={xScale(d.x) + 5}
-          cy={yScale(d.y)}
-          rx={borderRadius}
-          ry={borderRadius}
-          width={xScale.bandwidth()}
           x={xScale(d.x)}
           y={yScale(d.y)}
-          data-key={xDataKey}
-          data-value={d.y}
-
-      />
-        <rect
+          width={xScale.bandwidth()}
+          height={filledInRectangleHeight}
+          className='shadow'
           fill={fillColor}
-          fillOpacity={0}
-          height={innerHeight}
-          data-tooltip-pos={innerHeight - yScale(d.y)}
-          key={`${i}-container`}
-          cx={xScale(d.x) + 5}
-          cy={innerHeight}
+          data-tooltip-pos={filledInRectangleHeight}
+          key={i}
           rx={borderRadius}
           ry={borderRadius}
-          width={xScale.bandwidth()}
-          x={xScale(d.x)}
-          y={0}
           data-key={xDataKey}
           data-value={d.y}
-
+      />
+        <rect
+          x={xScale(d.x)}
+          y={0}
+          width={xScale.bandwidth()}
+          height={innerHeight}
+          fill={fillColor}
+          fillOpacity={0}
+          data-tooltip-pos={filledInRectangleHeight}
+          key={`${i}-container`}
+          rx={borderRadius}
+          ry={borderRadius}
+          data-key={xDataKey}
+          data-value={d.y}
+          data-tooltip-x={xScale(d.x) + 5}
+          data-tooltip-y={innerHeight}
+          onMouseEnter={props.showToolTip}
+          onMouseOut={props.hideToolTip}
       />
         { (props.showIcon)
         ? <image
           xmlns='http://www.w3.org/2000/svg'
-          xlinkHref={iconUri}
           x={(xScale(d.x))}
-          key={`${i}-i`}
-          y={innerHeight / 2}
+          y={iconY}
           width={xScale.bandwidth()}
           height='50px'
+          xlinkHref={iconUri}
+          key={`${i}-i`}
           className='svgicon'
-          cx={xScale(d.x)}
-          cy={yScale(d.y)}
           pointerEvents='none'
-
         />
        : '' }
         { (props.showXLabel)
-        ? <text fontSize={props.XLabelFontSize} x={(xScale(d.x)) + (xScale.bandwidth() / 2)} key={`${i}-t`} width={xScale.bandwidth()} y={innerHeight + 13} fill={palette.grey} textAnchor='middle'>
+        ? <text
+          fontSize={props.XLabelFontSize}
+          x={(xScale(d.x)) + (xScale.bandwidth() / 2)}
+          key={`${i}-t`}
+          width={xScale.bandwidth()}
+          y={innerHeight + 13}
+          fill={palette.grey}
+          textAnchor='middle'>
           {xDateLabel}
         </text>
       : '' }


### PR DESCRIPTION
If the icon fits within the filled-in rectangle of the BarChart, then display it at a fixed vertical position (same behavior as previous commit but a little lower on the y-axis). Otherwise, the icon floats a few pixels above the height of the filled-in rectangle (new behavior from this commit).

Renamed the cx/cy attributes to more correctly identify them as tooltip positions, since cx/cy are legitimate SVG attributes but not for rectangles, which was a little confusing to figure out.

Moved the tooltip mouse events to be tied to the invisible full-height rectangle, which allows us to remove duplicated attributes, and displays the tooltip when mousing over the expected area. This also fixes the unreported issue where mousing over the date label would fire a tooltip that had `null` in it.

Fixed the examples markdown to illustrate the icon behavior at different bar heights.

![octagon-icon-floag](https://cloud.githubusercontent.com/assets/3254856/25594512/c28e55e0-2e75-11e7-96ee-fea1db19fdac.png)