### PR TITLE
feat(all): upgrade to react 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "postcss-loader": "^1.1.0",
     "postcss-neat": "^2.5.2",
     "react-remarkable": "^1.1.1",
-    "react-styleguidist": "beta",
-    "react-test-renderer": "^15.4.0",
+    "react-styleguidist": "^5.2.1",
+    "react-test-renderer": "^15.5.4",
     "ripcord": "^1.1.1",
     "rucksack-css": "^0.9.1",
     "semantic-release": "^6.3.2",
@@ -58,11 +58,12 @@
   "dependencies": {
     "d3": "^4.7.1",
     "elegant-icons": "^0.0.1",
-    "flexbox-react": "^4.2.1",
+    "flexbox-react": "^4.3.3",
     "lato-font": "^2.0.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "semantic-ui-react": "^0.66.0"
+    "prop-types": "^15.5.10",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "semantic-ui-react": "^0.68.3"
   },
   "scripts": {
     "build": "node scripts/build",

--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import '../styles/components/favorite-button.css'
 
@@ -20,7 +21,7 @@ FavoriteButton.defaultProps = {
 }
 
 FavoriteButton.propTypes = {
-  isFavorited: React.PropTypes.bool
+  isFavorited: PropTypes.bool
 }
 
 export default FavoriteButton

--- a/src/components/LargeCard/LargeCard.jsx
+++ b/src/components/LargeCard/LargeCard.jsx
@@ -1,5 +1,6 @@
 import '../../styles/components/large-card.css'
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import LargeCardAction from './LargeCardAction'
@@ -45,8 +46,8 @@ LargeCard.defaultProps = {
   showCard: false
 }
 LargeCard.propTypes = {
-  className: React.PropTypes.string,
-  framed: React.PropTypes.bool,
-  showCard: React.PropTypes.bool
+  className: PropTypes.string,
+  framed: PropTypes.bool,
+  showCard: PropTypes.bool
 }
 export default LargeCard

--- a/src/components/LargeCard/LargeCardKeyValue.jsx
+++ b/src/components/LargeCard/LargeCardKeyValue.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -17,8 +18,8 @@ LargeCardKeyValue.defaultProps = {
 }
 
 LargeCardKeyValue.propTypes = {
-  name: React.PropTypes.string,
-  value: React.PropTypes.number
+  name: PropTypes.string,
+  value: PropTypes.number
 }
 
 export default LargeCardKeyValue

--- a/src/components/LargeCard/LargeCardRecentList.jsx
+++ b/src/components/LargeCard/LargeCardRecentList.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import Icon from '../suir/icon/Icon'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
@@ -49,7 +50,7 @@ LargeCardRecentList.defaultProps = {
 }
 
 LargeCardRecentList.propTypes = {
-  items: React.PropTypes.array
+  items: PropTypes.array
 }
 
 export default LargeCardRecentList

--- a/src/components/LargeCard/LargeCardStat.jsx
+++ b/src/components/LargeCard/LargeCardStat.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -18,8 +19,8 @@ LargeCardStat.defaultProps = {
 }
 
 LargeCardStat.propTypes = {
-  label: React.PropTypes.string,
-  value: React.PropTypes.number
+  label: PropTypes.string,
+  value: PropTypes.number
 }
 
 export default LargeCardStat

--- a/src/components/LargeCard/LargeCardTitle.jsx
+++ b/src/components/LargeCard/LargeCardTitle.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -18,8 +19,8 @@ LargeCardTitle.defaultProps = {
 }
 
 LargeCardTitle.propTypes = {
-  title: React.PropTypes.string,
-  description: React.PropTypes.string
+  title: PropTypes.string,
+  description: PropTypes.string
 }
 
 export default LargeCardTitle

--- a/src/components/MicroCard/MicroCard.jsx
+++ b/src/components/MicroCard/MicroCard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import MicroCardGutter from './MicroCardGutter'
@@ -32,7 +33,7 @@ class MicroCard extends React.Component {
 }
 
 MicroCard.propTypes = {
-  cardContent: React.PropTypes.object
+  cardContent: PropTypes.object
 }
 
 export default MicroCard

--- a/src/components/MicroCard/MicroCardContent.jsx
+++ b/src/components/MicroCard/MicroCardContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import MicroCardContentStatus from './MicroCardContentStatus'
@@ -28,7 +29,7 @@ MicroCardContent.defaultProps = {
 }
 
 MicroCardContent.propTypes = {
-  title: React.PropTypes.string
+  title: PropTypes.string
 }
 
 export default MicroCardContent

--- a/src/components/MicroCard/MicroCardContentMessage.jsx
+++ b/src/components/MicroCard/MicroCardContentMessage.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
@@ -33,7 +34,7 @@ MicroCardContentMessage.defaultProps = {
 }
 
 MicroCardContentMessage.propTypes = {
-  status: React.PropTypes.string
+  status: PropTypes.string
 }
 
 export default MicroCardContentMessage

--- a/src/components/MicroCard/MicroCardContentStatus.jsx
+++ b/src/components/MicroCard/MicroCardContentStatus.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
@@ -30,7 +31,7 @@ MicroCardContentStatus.defaultProps = {
 }
 
 MicroCardContentStatus.propTypes = {
-  status: React.PropTypes.string
+  status: PropTypes.string
 }
 
 export default MicroCardContentStatus

--- a/src/components/MicroCard/MicroCardCount.jsx
+++ b/src/components/MicroCard/MicroCardCount.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
@@ -14,7 +15,7 @@ MicroCardCount.defaultProps = {
 }
 
 MicroCardCount.propTypes = {
-  color: React.PropTypes.string
+  color: PropTypes.string
 
 }
 

--- a/src/components/MicroCard/MicroCardFavorite.jsx
+++ b/src/components/MicroCard/MicroCardFavorite.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import FavoriteButton from '../FavoriteButton'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
@@ -16,7 +17,7 @@ MicroCardFavorite.defaultProps = {
 }
 
 MicroCardFavorite.propTypes = {
-  isFavorited: React.PropTypes.bool
+  isFavorited: PropTypes.bool
 }
 
 export default MicroCardFavorite

--- a/src/components/MicroCard/MicroCardGutter.jsx
+++ b/src/components/MicroCard/MicroCardGutter.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import palette from '../../palette'
@@ -38,7 +39,7 @@ MicroCardGutter.defaultProps = {
 }
 
 MicroCardGutter.propTypes = {
-  color: React.PropTypes.string
+  color: PropTypes.string
 
 }
 

--- a/src/components/MicroCard/MicroCardGutter.jsx
+++ b/src/components/MicroCard/MicroCardGutter.jsx
@@ -29,7 +29,6 @@ const MicroCardGutter = (props) => {
       {...externalAttributes}
       className={`microcard state__indicator ${props.className}`}
       style={{ backgroundColor: color }}
-      width='8px'
     />
   )
 }

--- a/src/components/NotificationItem.jsx
+++ b/src/components/NotificationItem.jsx
@@ -55,7 +55,9 @@ const NotificationItem = (props) => {
   return (
 
     <li className={` ${notificationClass}`} key={props.notification.id} >
-      <Flexbox alignItems='center' className={`notification__selection notification__state-${props.notification.state} same-timegroup-${sameTimeGroup}`}>
+      <Flexbox alignItems='center'
+        className={`notification__selection notification__state-${props.notification.state}
+        same-timegroup-${sameTimeGroup}`}>
         <Flexbox flexDirection='row' flexGrow={3}>
           {sameTimeGroup
           ? <Flexbox className='no-timegroup' paddingRight='30px' />
@@ -63,7 +65,10 @@ const NotificationItem = (props) => {
               <Flexbox className='notification__time' alignItems='center' paddingLeft='15px' paddingRight='15px'>
                 {timeFormatted}H
             </Flexbox>
-              <Flexbox className={`notification__connection__dot notification__connection__dot_${props.notification.state}`} alignItems='center' marginRight='15px' />
+              <Flexbox
+                className={`notification__connection__dot notification__connection__dot_${props.notification.state}`}
+                alignItems='center'
+                marginRight='15px' />
             </Flexbox>
         }
           <span className='notification__vertical__line' />
@@ -75,7 +80,10 @@ const NotificationItem = (props) => {
             {notificationCount}&nbsp;{props.notification.name}
           </Flexbox>
         </Flexbox>
-        <Flexbox flexDirection='column' height='100%' alignItems='flex-end' justifyContent='center' className={`icon-right icon-right-${props.notification.state}`}>
+        <Flexbox flexDirection='column' height='100%'
+          alignItems='flex-end'
+          justifyContent='center'
+          className={`icon-right icon-right-${props.notification.state}`}>
           <i className='arrow_carrot-right' />
         </Flexbox>
       </Flexbox>

--- a/src/components/NotificationItem.jsx
+++ b/src/components/NotificationItem.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import * as d3 from 'd3'
 import Flexbox from 'flexbox-react'
@@ -83,7 +84,7 @@ const NotificationItem = (props) => {
   )
 }
 NotificationItem.propTypes = {
-  notification: React.PropTypes.object,
-  data: React.PropTypes.array
+  notification: PropTypes.object,
+  data: PropTypes.array
 }
 export default NotificationItem

--- a/src/components/PaginationControl.jsx
+++ b/src/components/PaginationControl.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 import '../styles/components/pagination-control.css'
@@ -90,10 +91,10 @@ class PaginationControl extends React.Component {
 }
 
 PaginationControl.propTypes = {
-  totalItems: React.PropTypes.number.isRequired,
-  navigateToPage: React.PropTypes.func.isRequired,
-  perPage: React.PropTypes.number.isRequired,
-  controlsDisabled: React.PropTypes.bool
+  totalItems: PropTypes.number.isRequired,
+  navigateToPage: PropTypes.func.isRequired,
+  perPage: PropTypes.number.isRequired,
+  controlsDisabled: PropTypes.bool
 }
 
 export default PaginationControl

--- a/src/components/StopStartButton.jsx
+++ b/src/components/StopStartButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Icon from './suir/icon/Icon'
 import '../styles/components/stop-start-button.css'
@@ -20,9 +21,9 @@ StopStartButton.defaultProps = {
 }
 
 StopStartButton.propTypes = {
-  isStopped: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
-  style: React.PropTypes.object
+  isStopped: PropTypes.bool,
+  onClick: PropTypes.func,
+  style: PropTypes.object
 }
 
 export default StopStartButton

--- a/src/components/TagButton.jsx
+++ b/src/components/TagButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import Flexbox from 'flexbox-react'
 
@@ -33,6 +34,6 @@ TagButton.defaultProps = {
 }
 
 TagButton.propTypes = {
-  tag: React.PropTypes.object
+  tag: PropTypes.object
 }
 export default TagButton

--- a/src/components/ThinCard/ThinCard.jsx
+++ b/src/components/ThinCard/ThinCard.jsx
@@ -1,5 +1,6 @@
 import '../../styles/components/thin-card.css'
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import ThinCardTitle from './ThinCardTitle'
@@ -48,7 +49,7 @@ ThinCard.defaultProps = {
   noBorder: false
 }
 ThinCard.propTypes = {
-  folder: React.PropTypes.bool,
-  noBorder: React.PropTypes.bool
+  folder: PropTypes.bool,
+  noBorder: PropTypes.bool
 }
 export default ThinCard

--- a/src/components/ThinCard/ThinCardActionButton.jsx
+++ b/src/components/ThinCard/ThinCardActionButton.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -19,8 +20,8 @@ ThinCardActionButton.defaultProps = {
 }
 
 ThinCardActionButton.propTypes = {
-  style: React.PropTypes.object,
-  innerDivClassName: React.PropTypes.object
+  style: PropTypes.object,
+  innerDivClassName: PropTypes.object
 }
 
 export default ThinCardActionButton

--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import Icon from '../suir/icon/Icon'
@@ -38,7 +39,7 @@ ThinCardDrawer.defaultProps = {
   expanded: false
 }
 ThinCardDrawer.propTypes = {
-  expanded: React.PropTypes.bool,
-  expandGroupToggle: React.PropTypes.func
+  expanded: PropTypes.bool,
+  expandGroupToggle: PropTypes.func
 }
 export default ThinCardDrawer

--- a/src/components/ThinCard/ThinCardPrimaryAction.jsx
+++ b/src/components/ThinCard/ThinCardPrimaryAction.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -21,8 +22,8 @@ ThinCardPrimaryAction.defaultProps = {
 }
 
 ThinCardPrimaryAction.propTypes = {
-  style: React.PropTypes.object,
-  className: React.PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.object
 }
 
 export default ThinCardPrimaryAction

--- a/src/components/ThinCard/ThinCardTitle.jsx
+++ b/src/components/ThinCard/ThinCardTitle.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -21,8 +22,8 @@ ThinCardTitle.defaultProps = {
 }
 
 ThinCardTitle.propTypes = {
-  style: React.PropTypes.object,
-  className: React.PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.object
 }
 
 export default ThinCardTitle

--- a/src/components/ThinCard/ThinCardWidget.jsx
+++ b/src/components/ThinCard/ThinCardWidget.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 import ThinCardWidgetLabel from './ThinCardWidgetLabel'
@@ -40,10 +41,10 @@ ThinCardWidget.defaultProps = {
 }
 
 ThinCardWidget.propTypes = {
-  borderLeft: React.PropTypes.bool,
-  borderRight: React.PropTypes.bool,
-  className: React.PropTypes.object,
-  onClick: React.PropTypes.func
+  borderLeft: PropTypes.bool,
+  borderRight: PropTypes.bool,
+  className: PropTypes.object,
+  onClick: PropTypes.func
 }
 
 export default ThinCardWidget

--- a/src/components/ThinCard/ThinCardWidgetLabel.jsx
+++ b/src/components/ThinCard/ThinCardWidgetLabel.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -21,8 +22,8 @@ ThinCardWidgetLabel.defaultProps = {
 }
 
 ThinCardWidgetLabel.propTypes = {
-  style: React.PropTypes.object,
-  className: React.PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.object
 }
 
 export default ThinCardWidgetLabel

--- a/src/components/ThinCard/ThinCardWidgetValue.jsx
+++ b/src/components/ThinCard/ThinCardWidgetValue.jsx
@@ -1,4 +1,5 @@
 import Flexbox from 'flexbox-react'
+import PropTypes from 'prop-types'
 import React from 'react'
 import filterAttributesFromProps from '../../util/externalAttributeFilter'
 
@@ -20,7 +21,7 @@ ThinCardWidgetValue.defaultProps = {
 }
 
 ThinCardWidgetValue.propTypes = {
-  style: React.PropTypes.object,
-  className: React.PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.object
 }
 export default ThinCardWidgetValue

--- a/src/components/TopNav/TopNav.jsx
+++ b/src/components/TopNav/TopNav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import TopNavContent from './TopNavContent'
 import LocalTime from './TopNavLocalTime'
@@ -16,7 +17,7 @@ class TopNav extends React.Component {
 
 TopNav.propTypes = {
   /** One of: Content, LocalTime, Node */
-  children: React.PropTypes.node
+  children: PropTypes.node
 }
 
 export default TopNav

--- a/src/components/TopNav/TopNavContent.jsx
+++ b/src/components/TopNav/TopNavContent.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const TopNavContent = (props) => {
@@ -15,7 +16,7 @@ TopNavContent.defaultProps = {
 }
 
 TopNavContent.propTypes = {
-  align: React.PropTypes.string
+  align: PropTypes.string
 }
 
 export default TopNavContent

--- a/src/components/charts/AreaChart/AreaChart.jsx
+++ b/src/components/charts/AreaChart/AreaChart.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import PlotArea from './PlotArea'
 import Axis from './Axis'
@@ -183,18 +184,18 @@ class AreaChart extends React.Component {
 }
 
 AreaChart.propTypes = {
-  data: React.PropTypes.array.isRequired,
-  dotVisible: React.PropTypes.bool,
-  height: React.PropTypes.number,
-  hideAxisX: React.PropTypes.bool,
-  hideAxisY: React.PropTypes.bool,
-  tooltipContentType: React.PropTypes.array.isRequired,
-  tooltipVisible: React.PropTypes.bool,
-  width: React.PropTypes.number,
-  xDataType: React.PropTypes.string.isRequired,
-  yBuffer: React.PropTypes.number.isRequired,
-  tooltipWidth: React.PropTypes.number,
-  tooltipHeight: React.PropTypes.number
+  data: PropTypes.array.isRequired,
+  dotVisible: PropTypes.bool,
+  height: PropTypes.number,
+  hideAxisX: PropTypes.bool,
+  hideAxisY: PropTypes.bool,
+  tooltipContentType: PropTypes.array.isRequired,
+  tooltipVisible: PropTypes.bool,
+  width: PropTypes.number,
+  xDataType: PropTypes.string.isRequired,
+  yBuffer: PropTypes.number.isRequired,
+  tooltipWidth: PropTypes.number,
+  tooltipHeight: PropTypes.number
 }
 
 AreaChart.defaultProps = {

--- a/src/components/charts/AreaChart/Axis.jsx
+++ b/src/components/charts/AreaChart/Axis.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import ReactDOM from 'react-dom'
 
 var d3 = Object.assign({}, require('d3-selection'), require('d3-axis'))

--- a/src/components/charts/AreaChart/PlotArea.jsx
+++ b/src/components/charts/AreaChart/PlotArea.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 var d3 = Object.assign({}, require('d3-shape'))
 const { array, func, string } = PropTypes
 

--- a/src/components/charts/AreaChart/ToolTip.jsx
+++ b/src/components/charts/AreaChart/ToolTip.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const ToolTip = (props) => {
@@ -46,8 +47,8 @@ const ToolTip = (props) => {
 }
 
 ToolTip.propTypes = {
-  tooltip: React.PropTypes.object,
-  children: React.PropTypes.node
+  tooltip: PropTypes.object,
+  children: PropTypes.node
 }
 
 export default ToolTip

--- a/src/components/charts/BarChart/BarChart.jsx
+++ b/src/components/charts/BarChart/BarChart.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import Rect from './Rect'
 import ToolTip from './BarChartTooltip'
 import * as ChartUtils from '../Chart/utils'

--- a/src/components/charts/BarChart/BarChartTooltip.jsx
+++ b/src/components/charts/BarChart/BarChartTooltip.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const ToolTip = (props) => {
@@ -68,7 +69,7 @@ const ToolTip = (props) => {
 }
 
 ToolTip.propTypes = {
-  tooltip: React.PropTypes.object
+  tooltip: PropTypes.object
 }
 
 export default ToolTip

--- a/src/components/charts/BarChart/Rect.jsx
+++ b/src/components/charts/BarChart/Rect.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import palette from '../../../palette'
 var d3 = Object.assign({}, require('d3-time-format'))
 
@@ -114,8 +115,8 @@ Rect.propTypes = {
   xDataType: string.isRequired,
   xScale: func.isRequired,
   yScale: func.isRequired,
-  showXLabel: React.PropTypes.bool,
-  showIcon: React.PropTypes.bool,
+  showXLabel: PropTypes.bool,
+  showIcon: PropTypes.bool,
   XLabelFontSize: string
 }
 

--- a/src/components/charts/Chart/Axis.jsx
+++ b/src/components/charts/Chart/Axis.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import ReactDOM from 'react-dom'
 var d3 = Object.assign({}, require('d3-selection'), require('d3-axis'))
 

--- a/src/components/charts/Chart/ChartOverlay.jsx
+++ b/src/components/charts/Chart/ChartOverlay.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import ReactDOM from 'react-dom'
 
 var d3 = Object.assign({}, require('d3-selection'), require('d3-array'))

--- a/src/components/charts/Chart/Dots.jsx
+++ b/src/components/charts/Chart/Dots.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 // import Immutable from 'immutable';
 var d3 = Object.assign({}, require('d3-time-format'))
@@ -29,12 +30,12 @@ const Dots = (props) => {
 }
 
 Dots.propTypes = {
-  showToolTip: React.PropTypes.func,
-  hideToolTip: React.PropTypes.func,
-  data: React.PropTypes.array,
-  xScale: React.PropTypes.func,
-  yScale: React.PropTypes.func,
-  xDataType: React.PropTypes.string
+  showToolTip: PropTypes.func,
+  hideToolTip: PropTypes.func,
+  data: PropTypes.array,
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+  xDataType: PropTypes.string
 }
 
 Dots.defaultProps = {

--- a/src/components/charts/Chart/Grid.jsx
+++ b/src/components/charts/Chart/Grid.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
 var d3 = Object.assign({}, require('d3-selection'))
@@ -30,9 +31,9 @@ class Grid extends React.Component {
 }
 
 Grid.propTypes = {
-  height: React.PropTypes.number,
-  grid: React.PropTypes.func,
-  gridType: React.PropTypes.oneOf(['x', 'y'])
+  height: PropTypes.number,
+  grid: PropTypes.func,
+  gridType: PropTypes.oneOf(['x', 'y'])
 }
 
 export default Grid

--- a/src/components/charts/Chart/ToolTip.jsx
+++ b/src/components/charts/Chart/ToolTip.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const ToolTip = (props) => {
@@ -44,7 +45,7 @@ const ToolTip = (props) => {
 }
 
 ToolTip.propTypes = {
-  tooltip: React.PropTypes.object
+  tooltip: PropTypes.object
 }
 
 export default ToolTip

--- a/src/components/charts/CircleChart/Circle.jsx
+++ b/src/components/charts/CircleChart/Circle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import palette from '../../../palette'
 import filterAttributesFromProps from '../../../util/externalAttributeFilter'
@@ -56,13 +57,13 @@ const CircleChart = (props) => {
 }
 
 CircleChart.propTypes = {
-  color: React.PropTypes.string,
-  border: React.PropTypes.number,
-  endPercent: React.PropTypes.number,
-  radius: React.PropTypes.number,
-  padding: React.PropTypes.number,
-  endPercentValue: React.PropTypes.string,
-  backgroundOpacity: React.PropTypes.number
+  color: PropTypes.string,
+  border: PropTypes.number,
+  endPercent: PropTypes.number,
+  radius: PropTypes.number,
+  padding: PropTypes.number,
+  endPercentValue: PropTypes.string,
+  backgroundOpacity: PropTypes.number
 }
 
 CircleChart.defaultProps = {

--- a/src/styles/components/micro-card.css
+++ b/src/styles/components/micro-card.css
@@ -1,28 +1,29 @@
-
 @import '../variables.css';
-
-
 
 .microcard {
   cursor: pointer;
   display: block;
-  float: left;
   color: var(--darkgray);
   width: 300px;
   font-size: var(--small);
 
-  min-height: 86px;
+  height: 90px;
   position: relative;
   & .text-uppercase {
-      text-transform: uppercase;
+    text-transform: uppercase;
   }
   &.bordered {
-    /* border: 2px solid color(var(--yellow)); */
     border: 2px solid color(var(--lightgray));
-  }  
+  }
   & .box__header {
     font-size: 1.2em;
     color: var(--textGray);
+  }
+
+  &.state__indicator {
+    float: left;
+    width: 8px;
+    height: 100%
   }
 
   & .microcard_favorite {
@@ -31,16 +32,13 @@
     top: 5px;
 
   }
-  & .text-critical{
+  & .text-critical {
     color: var(--red);
   }
-  & .text-warning{
+  & .text-warning {
     color: var(--yellow);
   }
   & .microcard__message {
-    display: block;
-    
-    
     text-transform: uppercase;
     & h3, & h4 {
       margin: 0;
@@ -60,14 +58,13 @@
 
   }
   & .microcard__count {
-    bottom: 20px;
+    bottom: 5px;
     font-size: 2.65rem;
     position: absolute;
     right: 25px;
     color: #A6A8AB;
   }
 }
-
 
 .microcard__arrow-right {
   bottom: 0;
@@ -79,5 +76,5 @@
   font-size: 28px !important;
   text-align: center;
   vertical-align: middle;
-  
+
 }

--- a/src/styles/components/notification-item.css
+++ b/src/styles/components/notification-item.css
@@ -5,7 +5,7 @@
 .tagContainer{
   cursor: pointer;
   margin-left: 1em;
-  
+
 }
 
 .ui.dropdown .menu{
@@ -65,17 +65,17 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     position: relative;
     display: inline-block;
     background: #363d43;
-   
+
     font-size: 30px !important;
   }
   & .notification-center__heading-title {
-    
-    
+
+
     letter-spacing: 1px;
     margin-left: 15px;
     text-transform: uppercase;
     font-size: 1.4em;
-    
+
   }
   & .text-large{
     font-size: 2em;
@@ -136,7 +136,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     border-right: 1px solid #333;
   }
   & .summary__total {
-    
+
     color: white;
     cursor: pointer;
     display: block;
@@ -181,11 +181,10 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   & .summary__total__text{
     color: #9facad;
     font-size: 1.65em;
-  }  
+  }
 }
 
 .notification__list {
-  float: left;
   list-style: none;
   margin-top: 0;
 
@@ -212,7 +211,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   & .notification__selection {
     color: #CA5318;
     & .icon-right {
-      
+
       color: white;
 
     }
@@ -230,7 +229,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     }
     & .notification__connection__dot {
       border: 0;
-      
+
     }
     & .notification__connection__dot_warning{
       background: var(--yellow);
@@ -247,7 +246,6 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
 .notification__selection {
   color: #596A7A;
   cursor: pointer;
-  display: block;
   font-size: var(--small);
   /*padding: 15px;*/
   height: 54px;
@@ -257,7 +255,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     position: relative;
     z-index: 10;
     font-size: 1.25rem;
-    
+
     font-size: 1.75rem;
   }
   & .pull-right {
@@ -274,7 +272,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     border: 3px solid gray;
     display: inline-block;
     height: 15px;
-    
+
     position: relative;
     top: 2px;
     width: 15px;
@@ -296,18 +294,18 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     width: 79px;
   }
   &.same-timegroup-true {
-    margin-top: -15px; 
+    margin-top: -15px;
     & .notification__vertical__line {
       height: 90%;
       top: 20px;
     }
-  } 
+  }
   & .notification__connection__state {
     max-width: 18px;
     display: inline-block;
     margin-right: 15px;
     position: relative;
-    
+
   }
   & .notification__connection__state img {
     max-width: 100%;
@@ -378,7 +376,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   position: relative;
   transform: translateX(0px);
   width: 320px;
-  
+
   float: left;
   & .tags__group {
     list-style: none;
@@ -394,8 +392,8 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
     & span {
       display: block;
       float: left;
-      
-    } 
+
+    }
 
   }
   & .tag__item_text{
@@ -409,10 +407,10 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   & .tags__group__current {
     cursor: pointer;
     & i {
-      
+
       display: inline-block;
       position: relative;
-      
+
     }
     & .tags__group__current_title{
       background-color: #e0e1e2;
@@ -526,7 +524,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   }
   & .tags__opener {
     color: var(--blue);
-    
+
     font-size: 11px;
     cursor: pointer;
     border-top: 2px solid #C6DCEB;
@@ -539,7 +537,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   & .tags__list {
     transition: height .5s, padding-top .5s, padding-bottom .5s;
     background-color: var(--taggray);
-    list-style: none; 
+    list-style: none;
     height: 260px;
     padding-left: 15px;
     padding-top: 20px;
@@ -594,23 +592,23 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
         background: #2CAFDC;
         border: 2px solid #2CAFDC;
       }
-    } 
+    }
   }
   & .tag__selection {
     background: none;
     border-bottom-left-radius: 3px;
     border-top-left-radius: 3px;
-    
+
     border-radius: 3px;
     color: var(--darkgray);
     cursor: pointer;
     display: block;
     float: left;
     font-size: var(--small);
-    
+
     padding: 1px;
-    position: relative; 
-    text-decoration: none; 
+    position: relative;
+    text-decoration: none;
     text-transform: uppercase;
   }
   & .tag_icon_arrow {
@@ -684,21 +682,21 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
 
 .notification__setings__title {
   color: color(var(--gray));
-  margin: 7px 0; 
+  margin: 7px 0;
 }
 
 .notification__settings {
   list-style: none;
   padding: 0;
   & .setting__item {
-    border-bottom: 1px solid var(--lightgray); 
+    border-bottom: 1px solid var(--lightgray);
     position: relative;
   }
   & .setting__selection {
     display: block;
     font-size: var(--small);
     color: color(var(--gray));
-    padding: 7px 0px; 
+    padding: 7px 0px;
     padding-right: 80px;
     text-transform: uppercase;
   }
@@ -728,7 +726,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   }
 
   & input.cmn-toggle-round + label {
-    
+
     border-radius: 18px;
     height: 18px;
     padding: 2px;
@@ -745,7 +743,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   }
   & input.cmn-toggle-round + label:before {
     background-color: #f1f1f1;
-   
+
     padding: 2px;
     right: 1px;
     transition: background 0.4s;
@@ -753,7 +751,7 @@ box-shadow: -3px 0px 9px -4px rgba(0,0,0,0.31);
   }
   & input.cmn-toggle-round + label:after {
     background-color: #fff;
-    
+
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
     transition: margin 0.4s;
     transition-delay: 0s;

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,15 +64,15 @@
     conventional-changelog "0.0.17"
     github-url-from-git "^1.4.0"
 
-"@types/react-dom@^0.14.20":
+"@types/react-dom@^0.14.23":
   version "0.14.23"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-0.14.23.tgz#cecfcfad754b4c2765fe5d29b81b301889ad6c2e"
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^15.0.0":
-  version "15.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.15.tgz#c386d6906177c5ddaa5804e7f215010d77c33caf"
+"@types/react@*", "@types/react@^15.0.21":
+  version "15.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.24.tgz#8a75299dc37906df327c18ca918bf97a55e7123b"
 
 JSONStream@~1.3.1:
   version "1.3.1"
@@ -193,7 +193,7 @@ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
 
-ansi-regex@^2.0.0, ansi-regex@~2.1.1:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1, ansi-regex@~2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -366,13 +366,17 @@ ast-types@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.0.tgz#c8721c8747ae4d5b29b929e99c5317b4e8745623"
 
-ast-types@0.9.5, ast-types@^0.9.5:
+ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
 
 ast-types@^0.7.2:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.7.8.tgz#902d2e0d60d071bdcd46dc115e1809ed11c138a9"
+
+ast-types@^0.9.11:
+  version "0.9.11"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.11.tgz#371177bb59232ff5ceaa1d09ee5cad705b1a5aa9"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -1389,6 +1393,13 @@ buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1579,6 +1590,12 @@ clean-css@4.0.x, clean-css@^4.0.4:
   dependencies:
     source-map "0.5.x"
 
+clean-webpack-plugin@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.16.tgz#422a8e150bf3d5abfd3d14bfacb070e80fb2e23f"
+  dependencies:
+    rimraf "~2.5.1"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -1703,9 +1720,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@^5.18.2, codemirror@^5.24.2:
-  version "5.24.2"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.24.2.tgz#b55ca950fa009709c37df68eb133310ed89cf2fe"
+codemirror@^5.18.2, codemirror@^5.25.2:
+  version "5.25.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.25.2.tgz#8c77677ca9c9248d757d3a07ed1e89a8404850b7"
 
 collapse-white-space@^1.0.2:
   version "1.0.2"
@@ -1759,6 +1776,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@1.0.3, colors@1.0.x, colors@~1.0.2:
   version "1.0.3"
@@ -2049,13 +2070,23 @@ css-color-function@^1.2.0:
     debug "~0.7.4"
     rgb "~0.1.0"
 
+css-color-list@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/css-color-list/-/css-color-list-0.0.1.tgz#8718e8695ae7a2cc8787be8715f1c008a7f28b15"
+  dependencies:
+    css-color-names "0.0.1"
+
+css-color-names@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.1.tgz#5d0548fa256456ede4a9a0c2ac7ab19d3eb1ad81"
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader@^0.26.4:
-  version "0.26.4"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.26.4.tgz#b61e9e30db94303e6ffc892f10ecd09ad025a1fd"
+css-loader@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.1.tgz#220325599f8f00452d9ceb4c3ca6c8a66798642d"
   dependencies:
     babel-code-frame "^6.11.0"
     css-selector-tokenizer "^0.7.0"
@@ -2068,6 +2099,7 @@ css-loader@^0.26.4:
     postcss-modules-local-by-default "^1.0.1"
     postcss-modules-scope "^1.0.0"
     postcss-modules-values "^1.1.0"
+    postcss-value-parser "^3.3.0"
     source-list-map "^0.1.7"
 
 css-select@^1.1.0:
@@ -2094,6 +2126,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-1.0.6.tgz#728c7e774e56536558a0ecaa990d9507c43a4ac4"
+  dependencies:
+    css-color-list "0.0.1"
+    fbjs "^0.8.5"
+    nearley "^2.7.7"
 
 css-what@2.1:
   version "2.1.0"
@@ -2184,17 +2224,17 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-d3-array@1, d3-array@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.1.0.tgz#bfea66b89d46f9aedf77296d3aad6307b50771cc"
+d3-array@1, d3-array@1.2.0, d3-array@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.0.tgz#147d269720e174c4057a7f42be8b0f3f2ba53108"
 
-d3-axis@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.5.tgz#865db17a7b54433e3b35c1d2b1a76bdb7c3d434d"
+d3-axis@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.7.tgz#048433d307061f62d1d248e2930c01d7b6738cd8"
 
-d3-brush@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.3.tgz#4fa5374cc3b755d0990bf76b71b7a66417751c74"
+d3-brush@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.4.tgz#00c2f238019f24f6c0a194a26d41a1530ffe7bc4"
   dependencies:
     d3-dispatch "1"
     d3-drag "1"
@@ -2202,107 +2242,107 @@ d3-brush@1.0.3:
     d3-selection "1"
     d3-transition "1"
 
-d3-chord@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.3.tgz#a398bae7cb632a3c4ea687a555a6b9ee4609d990"
+d3-chord@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.4.tgz#7dec4f0ba886f713fe111c45f763414f6f74ca2c"
   dependencies:
     d3-array "1"
     d3-path "1"
 
-d3-collection@1, d3-collection@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.2.tgz#df5acb5400443e9eabe9c1379896c67e52426b39"
-
-d3-color@1, d3-color@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.2.tgz#83cb4b3a9474e40795f009d97e97a15649830bbc"
-
-d3-dispatch@1, d3-dispatch@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.2.tgz#5b511e79a46a1f89492841c0a8f656687d5daa0a"
-
-d3-drag@1, d3-drag@1.0.3:
+d3-collection@1, d3-collection@1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.0.3.tgz#a016d21c696d130ba758babf1cd9e5f049169d0b"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.3.tgz#00bdea94fbc1628d435abbae2f4dc2164e37dd34"
+
+d3-color@1, d3-color@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
+
+d3-dispatch@1, d3-dispatch@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
+
+d3-drag@1, d3-drag@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.1.0.tgz#4a49b4d77a42e9e3d5a0ef3b492b14aaa2e5a733"
   dependencies:
     d3-dispatch "1"
     d3-selection "1"
 
-d3-dsv@1, d3-dsv@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.4.tgz#2f491bcf00729d9ee6734f7cfb7049ddcc5e981d"
+d3-dsv@1, d3-dsv@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.5.tgz#419f7db47f628789fc3fdb636e678449d0821136"
   dependencies:
     commander "2"
     iconv-lite "0.4"
     rw "1"
 
-d3-ease@1, d3-ease@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.2.tgz#b486f8f3ca308ca7be38197d65622b6e30983377"
+d3-ease@1, d3-ease@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
 
-d3-force@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.0.5.tgz#be8f65ac70688b8d26a9d9bc1e4699c1525f46b1"
+d3-force@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.0.6.tgz#ea7e1b7730e2664cd314f594d6718c57cc132b79"
   dependencies:
     d3-collection "1"
     d3-dispatch "1"
     d3-quadtree "1"
     d3-timer "1"
 
-d3-format@1, d3-format@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.1.0.tgz#736775d5e6604421bef6c76d5746638a8e70d295"
+d3-format@1, d3-format@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 
-d3-geo@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.6.1.tgz#071aee9d54bcecc5c74958c4aec7b76c685b6f3b"
+d3-geo@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.6.4.tgz#f20e1e461cb1845f5a8be55ab6f876542a7e3199"
   dependencies:
     d3-array "1"
 
-d3-hierarchy@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.2.tgz#63d168424320fdb4f5c80df458e5bd0d9f2218e6"
+d3-hierarchy@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.4.tgz#96c3942f3f21cf997a11b4edf00dde2a77b4c6d0"
 
-d3-interpolate@1, d3-interpolate@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.3.tgz#e119c91b6be4941e581675ca3e1279bb92bd2c9b"
+d3-interpolate@1, d3-interpolate@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
   dependencies:
     d3-color "1"
 
-d3-path@1, d3-path@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.4.tgz#117d25933a7f8e38293b879094510cf2ef0e9367"
+d3-path@1, d3-path@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
 
-d3-polygon@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.2.tgz#6552c0fb03aa2d05023351da6e0e8adc4df0202b"
+d3-polygon@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.3.tgz#16888e9026460933f2b179652ad378224d382c62"
 
-d3-quadtree@1, d3-quadtree@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.2.tgz#e7e873af06aaa427eaa4af094cc4cbfb350b9e38"
+d3-quadtree@1, d3-quadtree@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.3.tgz#ac7987e3e23fe805a990f28e1b50d38fcb822438"
 
-d3-queue@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.4.tgz#6e549807c4b646e6768f0b2bdfdaaa6792f3d4a9"
+d3-queue@3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.7.tgz#c93a2e54b417c0959129d7d73f6cf7d4292e7618"
 
-d3-random@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.0.2.tgz#83ff6a391206209c30565299e43c6549866db269"
+d3-random@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.0.tgz#6642e506c6fa3a648595d2b2469788a8d12529d3"
 
-d3-request@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-request/-/d3-request-1.0.4.tgz#e04f559644f98639af24d75f8fcf99e3d27f1f53"
+d3-request@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-request/-/d3-request-1.0.5.tgz#4daae946d1dd0d57dfe01f022956354958d51f23"
   dependencies:
     d3-collection "1"
     d3-dispatch "1"
     d3-dsv "1"
     xmlhttprequest "1"
 
-d3-scale@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.4.tgz#50e28bf6a193b706745528515ed9b3d44205a033"
+d3-scale@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
   dependencies:
-    d3-array "1"
+    d3-array "^1.2.0"
     d3-collection "1"
     d3-color "1"
     d3-format "1"
@@ -2310,48 +2350,48 @@ d3-scale@1.0.4:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@1, d3-selection@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.0.4.tgz#b862c7ae22436efe8459b7659ccdae84f09b43a3"
+d3-selection@1, d3-selection@1.1.0, d3-selection@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.1.0.tgz#1998684896488f839ca0372123da34f1d318809c"
 
-d3-shape@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.0.5.tgz#2e1946fbd9cf468d9f8dc6d2e58d6c4278ae286a"
+d3-shape@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.1.1.tgz#50a1037e48a79f5b8fd9d58cde52799aeb1f7723"
   dependencies:
     d3-path "1"
 
-d3-time-format@2, d3-time-format@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.4.tgz#db0ab6910b3f2fc729a2ddfd2ac1b750962e1f72"
+d3-time-format@2, d3-time-format@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
   dependencies:
     d3-time "1"
 
-d3-time@1, d3-time@1.0.5:
+d3-time@1, d3-time@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.6.tgz#a55b13d7d15d3a160ae91708232e0835f1d5e945"
+
+d3-timer@1, d3-timer@1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.5.tgz#ef07a27d4b56522d984a41c27b1c67aa80b0cdd9"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.5.tgz#b266d476c71b0d269e7ac5f352b410a3b6fe6ef0"
 
-d3-timer@1, d3-timer@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.4.tgz#adaf7f60c7b54c99b2ffabd28c15a0c108a75321"
-
-d3-transition@1, d3-transition@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.0.3.tgz#91dc986bddb30973639320a85db72ce4ab1a27bb"
+d3-transition@1, d3-transition@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.0.tgz#cfc85c74e5239324290546623572990560c3966f"
   dependencies:
     d3-color "1"
     d3-dispatch "1"
     d3-ease "1"
     d3-interpolate "1"
-    d3-selection "1"
+    d3-selection "^1.1.0"
     d3-timer "1"
 
-d3-voronoi@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.1.tgz#998544dca98ef0e89a6c40c0bac3510d1bc1b8b9"
-
-d3-zoom@1.1.2:
+d3-voronoi@1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.1.2.tgz#a8944947e92a12bc5d5a3fb4dccf1a40e7de5fb3"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
+
+d3-zoom@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.2.0.tgz#b3231f4f9386241475defe1c557bfd3fde1065fb"
   dependencies:
     d3-dispatch "1"
     d3-drag "1"
@@ -2360,39 +2400,39 @@ d3-zoom@1.1.2:
     d3-transition "1"
 
 d3@^4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-4.7.1.tgz#3ab26b96a215e1f3180f83b6cb3c4656de9a63ab"
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-4.9.1.tgz#f860be9252261a3c14eea64b1d2590d14f4db838"
   dependencies:
-    d3-array "1.1.0"
-    d3-axis "1.0.5"
-    d3-brush "1.0.3"
-    d3-chord "1.0.3"
-    d3-collection "1.0.2"
-    d3-color "1.0.2"
-    d3-dispatch "1.0.2"
-    d3-drag "1.0.3"
-    d3-dsv "1.0.4"
-    d3-ease "1.0.2"
-    d3-force "1.0.5"
-    d3-format "1.1.0"
-    d3-geo "1.6.1"
-    d3-hierarchy "1.1.2"
-    d3-interpolate "1.1.3"
-    d3-path "1.0.4"
-    d3-polygon "1.0.2"
-    d3-quadtree "1.0.2"
-    d3-queue "3.0.4"
-    d3-random "1.0.2"
-    d3-request "1.0.4"
-    d3-scale "1.0.4"
-    d3-selection "1.0.4"
-    d3-shape "1.0.5"
-    d3-time "1.0.5"
-    d3-time-format "2.0.4"
-    d3-timer "1.0.4"
-    d3-transition "1.0.3"
-    d3-voronoi "1.1.1"
-    d3-zoom "1.1.2"
+    d3-array "1.2.0"
+    d3-axis "1.0.7"
+    d3-brush "1.0.4"
+    d3-chord "1.0.4"
+    d3-collection "1.0.3"
+    d3-color "1.0.3"
+    d3-dispatch "1.0.3"
+    d3-drag "1.1.0"
+    d3-dsv "1.0.5"
+    d3-ease "1.0.3"
+    d3-force "1.0.6"
+    d3-format "1.2.0"
+    d3-geo "1.6.4"
+    d3-hierarchy "1.1.4"
+    d3-interpolate "1.1.5"
+    d3-path "1.0.5"
+    d3-polygon "1.0.3"
+    d3-quadtree "1.0.3"
+    d3-queue "3.0.7"
+    d3-random "1.1.0"
+    d3-request "1.0.5"
+    d3-scale "1.0.6"
+    d3-selection "1.1.0"
+    d3-shape "1.1.1"
+    d3-time "1.0.6"
+    d3-time-format "2.0.5"
+    d3-timer "1.0.5"
+    d3-transition "1.1.0"
+    d3-voronoi "1.1.2"
+    d3-zoom "1.2.0"
 
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"
@@ -2425,7 +2465,13 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@2, debug@2.6.1, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.5:
+debug@2, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.3:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
+  dependencies:
+    ms "0.7.3"
+
+debug@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -2567,6 +2613,10 @@ diff@^3.0.0:
 diff@~1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.0.8.tgz#343276308ec991b7bc82267ed55bc1411f971666"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -2792,9 +2842,9 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
-es6-object-assign@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.0.3.tgz#40a192e0fda5ee44ee8cf6f5b5d9b47cd0f69b14"
+es6-object-assign@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
 
 es6-promise@^3.0.2, es6-promise@^3.1.2:
   version "3.3.1"
@@ -3162,7 +3212,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -3325,15 +3375,14 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flexbox-react@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/flexbox-react/-/flexbox-react-4.2.1.tgz#03c1923380976c7b2223d753c4b68df2ee35cd7f"
+flexbox-react@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/flexbox-react/-/flexbox-react-4.3.3.tgz#a5d5c6b59d68658045e7818387680821c5d3f193"
   dependencies:
-    inline-style-prefixer "^2.0.5"
-    lodash.pickby "^4.6.0"
+    styled-components "^1.4.5"
   optionalDependencies:
-    "@types/react" "^15.0.0"
-    "@types/react-dom" "^0.14.20"
+    "@types/react" "^15.0.21"
+    "@types/react-dom" "^0.14.23"
 
 flush-write-stream@^1.0.0:
   version "1.0.2"
@@ -4196,9 +4245,9 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-highlight.js@^9.10.0:
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.10.0.tgz#f9f0b14c0be00f0e4fb1e577b749fed9e6f52f55"
+highlight.js@^9.11.0:
+  version "9.11.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.11.0.tgz#47f98c7399918700db2caf230ded12cec41a84ae"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -4618,6 +4667,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -4680,6 +4733,12 @@ is-path-inside@^1.0.0:
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.1.tgz#4d7ca539bc9db9b737b8acb612f2318ef92f294f"
+  dependencies:
+    isobject "^1.0.0"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -4775,10 +4834,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isarray@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
-
 isemail@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
@@ -4790,6 +4845,10 @@ isexe@^1.1.1:
 isnumeric@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/isnumeric/-/isnumeric-0.2.0.tgz#a2347ba360de19e33d0ffd590fddf7755cbf2e64"
+
+isobject@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -5254,36 +5313,39 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jss-camel-case@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-3.0.0.tgz#46aa18eb149e95afce074532ad47df1c2a7d45cb"
+jss-camel-case@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-4.0.0.tgz#39ef2a137aaa1e2f160ab826845305f8efabcfd5"
 
-jss-compose@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-2.0.1.tgz#df881ac1fe310b49bab4ad4229b32abc69b3ee6f"
-  dependencies:
-    warning "^3.0.0"
-
-jss-default-unit@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-5.0.2.tgz#c4d7fd957cb41baab0b4cb37f92016aa1db08667"
-
-jss-isolate@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jss-isolate/-/jss-isolate-2.0.1.tgz#7ee5591e0dc5d358a2fbed25ccf0f2510413c896"
-
-jss-nested@^3.0.1:
+jss-compose@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-3.0.1.tgz#14c10265c8fc5bd61b450b48f1e9fb36d90ae569"
+  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-3.0.1.tgz#0ac07f20baf1d523c211016d383dab08dcfe4186"
   dependencies:
     warning "^3.0.0"
 
-jss@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-6.3.0.tgz#b4c894da4617669ef24a45079571f1d0f40b65eb"
+jss-default-unit@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-6.1.1.tgz#a9a04887a3860d2a8ceb73ddfbc2ddcf808bacb2"
+
+jss-global@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-1.0.1.tgz#36731778f6d8649110611f7c178dbcd60fd92b24"
+
+jss-isolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-isolate/-/jss-isolate-3.0.0.tgz#69f715a67a58db0ce0b99f55b330fe81d7a105d1"
+
+jss-nested@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-4.0.1.tgz#f50cc206430c8a920ccd54e3b756f7fc72455130"
+  dependencies:
+    warning "^3.0.0"
+
+jss@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-7.1.2.tgz#f927fa5a06bf0a309a3e9e92f00b3aebfe3ab27d"
   dependencies:
     is-in-browser "1.0.2"
-    murmurhash-js "1.0.0"
     warning "3.0.0"
 
 jsx-ast-utils@^1.3.4:
@@ -5450,9 +5512,17 @@ loader-utils@^0.2.11, loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.0.3:
+loader-utils@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.3.tgz#566c320c24c33cb3f02db4df83f3dbf60b253de3"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
+loader-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
@@ -5875,7 +5945,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5957,13 +6027,14 @@ markdown-table@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.0.tgz#1f5ae61659ced8808d882554c32e8b3f38dd1143"
 
-markdown-to-jsx@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-5.0.1.tgz#1c2aafd3a00a1a4a217c9549f0e7e506f2e38ee3"
+markdown-to-jsx@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-5.3.3.tgz#3e48548e15da0426f019eb95fa96f3397b95e012"
   dependencies:
     lodash.get "^4.4.2"
-    remark-parse "^2.0.1"
-    unified "^5.0.0"
+    prop-types "^15.5.8"
+    remark-parse "^3.0.0"
+    unified "^6.1.2"
 
 marked-terminal@^1.6.2:
   version "1.7.0"
@@ -6153,15 +6224,15 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
+
 multipipe@^0.1.0, multipipe@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/multipipe/-/multipipe-0.1.2.tgz#2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
   dependencies:
     duplexer2 "0.0.2"
-
-murmurhash-js@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -6196,6 +6267,14 @@ ncname@1.0.x:
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
   dependencies:
     xml-char-classes "^1.0.0"
+
+nearley@^2.7.7:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.9.2.tgz#b06e36b2341403a43e20b7da1f1d6a553f7389ea"
+  dependencies:
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "^0.4.2"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -6336,6 +6415,13 @@ node.extend@^1.1.3:
 nodesecurity-npm-utils@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz#05aa30de30ca8c845c4048e94fd78e5e08b55ed9"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 "nopt@2 || 3", nopt@~3.0.1, nopt@~3.0.6:
   version "3.0.6"
@@ -7638,6 +7724,13 @@ pretty-format@^19.0.0:
   dependencies:
     ansi-styles "^3.0.0"
 
+pretty-format@^20.0.0:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
+    ansi-styles "^3.0.0"
+
 pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -7675,6 +7768,19 @@ promzard@^0.3.0:
   resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
   dependencies:
     read "1"
+
+prop-types@15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -7768,6 +7874,17 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@^0.4.2:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.5.tgz#ffe3a80c3f666cd71e6b008e477e584c1a32ff3e"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -7817,11 +7934,11 @@ react-docgen-displayname-handler@^1.0.0:
   dependencies:
     recast "0.11.12"
 
-react-docgen@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.13.0.tgz#7fcc4a3104ea8d4fd428383ba38df11166837be9"
+react-docgen@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.15.0.tgz#11aced462256e4862b14e6af6e46bdcefacb28bb"
   dependencies:
-    async "^1.4.2"
+    async "^2.1.4"
     babel-runtime "^6.9.2"
     babylon "~5.8.3"
     commander "^2.9.0"
@@ -7829,17 +7946,20 @@ react-docgen@^2.13.0:
     node-dir "^0.1.10"
     recast "^0.11.5"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react-group@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-group/-/react-group-1.0.3.tgz#553f50e3588324c4bbb161a3e6832677a33c7a5b"
+react-group@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-group/-/react-group-1.0.4.tgz#13cd52f80169daf24bfc74847eb975c5d08d7a69"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-remarkable@^1.1.1:
   version "1.1.1"
@@ -7847,67 +7967,72 @@ react-remarkable@^1.1.1:
   dependencies:
     remarkable "^1.4.1"
 
-react-styleguidist@beta:
-  version "5.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/react-styleguidist/-/react-styleguidist-5.0.0-beta.15.tgz#1517e598aa94969b43aac2139ce7a1bc61c14917"
+react-styleguidist@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-styleguidist/-/react-styleguidist-5.2.1.tgz#0d8bd0062588693dac84d24b22aa2feec093acd2"
   dependencies:
-    ast-types "^0.9.5"
+    ast-types "^0.9.11"
     buble "^0.15.2"
     chalk "^1.1.3"
     classnames "^2.2.5"
-    codemirror "^5.24.2"
+    clean-webpack-plugin "^0.1.16"
+    codemirror "^5.25.2"
     common-dir "^1.0.1"
-    css-loader "^0.26.4"
-    es6-object-assign "~1.0.3"
+    css-loader "^0.28.1"
+    es6-object-assign "~1.1.0"
     escodegen "^1.8.1"
     findup "^0.1.5"
     function.name-polyfill "^1.0.5"
     github-slugger "^1.1.1"
     glob "^7.1.1"
-    highlight.js "^9.10.0"
+    highlight.js "^9.11.0"
     html-webpack-plugin "^2.28.0"
     is-directory "^0.3.1"
     json-loader "^0.5.4"
-    jss "^6.3.0"
-    jss-camel-case "^3.0.0"
-    jss-compose "^2.0.1"
-    jss-default-unit "^5.0.2"
-    jss-isolate "^2.0.1"
-    jss-nested "^3.0.1"
+    jss "^7.1.1"
+    jss-camel-case "^4.0.0"
+    jss-compose "^3.0.1"
+    jss-default-unit "^6.1.1"
+    jss-global "^1.0.1"
+    jss-isolate "^3.0.0"
+    jss-nested "^4.0.1"
     leven "^2.1.0"
     listify "^1.0.0"
-    loader-utils "^1.0.3"
+    loader-utils "^1.1.0"
     lodash "^4.17.4"
-    markdown-to-jsx "^5.0.1"
+    markdown-to-jsx "^5.3.3"
     minimist "^1.2.0"
-    pretty-format "^19.0.0"
+    pretty-format "^20.0.0"
+    prop-types "^15.5.8"
     react-codemirror "^0.3.0"
     react-dev-utils "^0.5.2"
-    react-docgen "^2.13.0"
+    react-docgen "^2.15.0"
     react-docgen-displayname-handler "^1.0.0"
-    react-group "^1.0.3"
-    remark "^7.0.0"
+    react-group "^1.0.4"
+    remark "^7.0.1"
     semver-utils "^1.1.1"
-    style-loader "^0.13.2"
+    style-loader "^0.17.0"
     to-ast "^1.0.0"
+    type-detect "^4.0.3"
     unist-util-visit "^1.1.1"
     webpack-dev-server "^1.16.3"
-    webpack-merge "^4.0.0"
+    webpack-merge "^4.1.0"
 
-react-test-renderer@^15.4.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -8211,27 +8336,6 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-remark-parse@^2.0.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-2.3.0.tgz#ced58bfbef9999374f9ff33fbc2e63fe2b0c5c37"
-  dependencies:
-    collapse-white-space "^1.0.2"
-    has "^1.0.1"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.0.2"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
-
 remark-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-3.0.0.tgz#f078c8c9976efb0f2afd011c79f30708354593b1"
@@ -8272,9 +8376,9 @@ remark-stringify@^3.0.0:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
-remark@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/remark/-/remark-7.0.0.tgz#ce9c788c390d98d9a67cb7738e98246732e79144"
+remark@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-7.0.1.tgz#a5de4dacfabf0f60a49826ef24c479807f904bfb"
   dependencies:
     remark-parse "^3.0.0"
     remark-stringify "^3.0.0"
@@ -8351,7 +8455,7 @@ request-promise@^4.1.1:
     request-promise-core "1.1.1"
     stealthy-require "^1.0.0"
 
-request@2, request@^2.72.0, request@^2.74.0, request@^2.75.0, request@^2.78.0, request@^2.79.0, request@~2.81.0:
+request@2, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.79.0, request@~2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -8378,7 +8482,7 @@ request@2, request@^2.72.0, request@^2.74.0, request@^2.75.0, request@^2.78.0, r
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@2.79.0, request@^2.58.0:
+request@2.79.0, request@^2.58.0, request@^2.75.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -8498,6 +8602,10 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.14.tgz#58c636837b12e161f8a380cf081c6a230fd1664e"
 
 retry@^0.10.0, retry@~0.10.1:
   version "0.10.1"
@@ -8746,14 +8854,15 @@ semantic-release@^6.3.2:
     run-series "^1.1.3"
     semver "^5.2.0"
 
-semantic-ui-react@^0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-0.66.0.tgz#6be04edc6a92be3c39f9e816bfb97f632dff8090"
+semantic-ui-react@^0.68.3:
+  version "0.68.3"
+  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-0.68.3.tgz#4caedb2cc307c80864d9bd55306b905de3b653e2"
   dependencies:
     babel-runtime "^6.22.0"
     classnames "^2.1.5"
-    debug "^2.4.5"
+    debug "^2.6.3"
     lodash "^4.17.2"
+    prop-types "15.5.8"
 
 semantic-ui@^2.2.6:
   version "2.2.9"
@@ -9330,6 +9439,25 @@ style-loader@^0.13.2:
   dependencies:
     loader-utils "^1.0.2"
 
+style-loader@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.17.0.tgz#e8254bccdb7af74bd58274e36107b4d5ab4df310"
+  dependencies:
+    loader-utils "^1.0.2"
+
+styled-components@^1.4.5:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.4.6.tgz#58f32e8a6ab510fb1481e901e838e0477f148b06"
+  dependencies:
+    buffer "^5.0.2"
+    css-to-react-native "^1.0.6"
+    fbjs "^0.8.7"
+    inline-style-prefixer "^2.0.5"
+    is-function "^1.0.1"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
+    supports-color "^3.1.2"
+
 subcommand@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/subcommand/-/subcommand-2.1.0.tgz#5e4ceca5a3779e3365b1511e05f866877302f760"
@@ -9639,6 +9767,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 type-is@~1.6.14:
   version "1.6.14"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.14.tgz#e219639c17ded1ca0789092dd54a03826b817cb2"
@@ -9703,6 +9835,10 @@ underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
 underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
@@ -9714,28 +9850,14 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
-unified@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-5.1.0.tgz#61268da9b91ce925be1f3d198c0278b0e9716094"
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    has "^1.0.1"
-    is-buffer "^1.1.4"
-    once "^1.3.3"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
-
-unified@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.1.tgz#0abb4d2ffd8f42c0bc06e4a62ff8eb8fd77f8d11"
+unified@^6.0.0, unified@^6.1.2:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.3.tgz#c26a9df2c56f3def938309253928f37150c70c6e"
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
     has "^1.0.1"
     is-plain-obj "^1.1.0"
-    isarray "^2.0.1"
     trough "^1.0.0"
     vfile "^2.0.0"
     x-is-function "^1.0.4"
@@ -10168,9 +10290,9 @@ webpack-dev-server@^1.16.3:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.4.0"
 
-webpack-merge@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.0.0.tgz#4347ebeb9e71aaa413baef66be74d4eb2656b66a"
+webpack-merge@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.0.tgz#6ad72223b3e0b837e531e4597c199f909361511e"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Upgrade to react 15.5.4.

This changes the way PropTypes are handled, pulling them in fro `prop-types` rather than from `react`.  This change in turn has rippled through most react related libraries and to avoid the deprecation warnings these have all been upgraded in this change set.

Behavior changes in flexbox-react caused a few problems with MicroCard and NotificationItem, these are also fixed.  No pictures since they are unchanged.
