### PR TITLE
fix(theme): drop dupe Lato font assets

### DIFF
--- a/semantic/src/themes/tripwire/globals/site.variables
+++ b/semantic/src/themes/tripwire/globals/site.variables
@@ -12,7 +12,7 @@
 @pageFont          : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 
 @googleFontName    : @fontName;
-@importGoogleFonts : true;
+@importGoogleFonts : false;
 @googleFontSizes   : '400,700,400italic,700italic';
 @googleSubset      : 'latin';
 


### PR DESCRIPTION
# problem statement

we bundle Lato locally, but pat noticed that the theme is also configured to pull in google fonts.

<!--
- X behaves this way, which breaks Y
-->

# solution

drop google fonts
<!--
- decouple X & Y
- make Y a standalone component, etc
-->
