### PR TITLE
fix(ThinCardDrawer) Move expand button to the left

### DIFF
--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -10,7 +10,6 @@ const ThinCardDrawer = (props) => {
     <div {...externalAttributes}>
       {(!props.expanded) ? (
         <Flexbox className='drawer' flexDirection='row' onClick={props.expandGroupToggle}>
-          <Flexbox className='drawer__side' flexGrow={3} />
           <Flexbox className='drawer__center' width='150px' paddingLeft='1em' paddingRight='1em'>
             <Flexbox alignItems='center' className='drawer__center_copy' flexGrow={2}>EXPAND</Flexbox>
             <Flexbox><Icon className='ei arrow_carrot-down text-large' /></Flexbox>


### PR DESCRIPTION
# problem statement

The ThinCard component centers the expand button under the card, but our desired UX has it on the left.

# solution

Move the expand button to the left.

# discussion

Here is the before and after:

**Before**
![old_thincard_expand](https://user-images.githubusercontent.com/564302/27052907-340a69d2-4f70-11e7-919e-eed868b7285b.JPG)

**After**
![new_thincard_expand](https://user-images.githubusercontent.com/564302/27052849-026343a4-4f70-11e7-8633-65f0aedbc3ae.JPG)
