### PR TITLE
fix(props) className prop types

### DIFF
--- a/src/components/ThinCard/ThinCardPrimaryAction.jsx
+++ b/src/components/ThinCard/ThinCardPrimaryAction.jsx
@@ -17,13 +17,12 @@ const ThinCardPrimaryAction = (props) => {
 }
 
 ThinCardPrimaryAction.defaultProps = {
-  style: {},
-  className: {}
+  style: {}
 }
 
 ThinCardPrimaryAction.propTypes = {
   style: PropTypes.object,
-  className: PropTypes.object
+  className: PropTypes.string
 }
 
 export default ThinCardPrimaryAction

--- a/src/components/ThinCard/ThinCardTitle.jsx
+++ b/src/components/ThinCard/ThinCardTitle.jsx
@@ -17,13 +17,12 @@ const ThinCardTitle = (props) => {
 }
 
 ThinCardTitle.defaultProps = {
-  style: {},
-  className: {}
+  style: {}
 }
 
 ThinCardTitle.propTypes = {
   style: PropTypes.object,
-  className: PropTypes.object
+  className: PropTypes.string
 }
 
 export default ThinCardTitle

--- a/src/components/ThinCard/ThinCardWidget.jsx
+++ b/src/components/ThinCard/ThinCardWidget.jsx
@@ -43,7 +43,7 @@ ThinCardWidget.defaultProps = {
 ThinCardWidget.propTypes = {
   borderLeft: PropTypes.bool,
   borderRight: PropTypes.bool,
-  className: PropTypes.object,
+  className: PropTypes.string,
   onClick: PropTypes.func
 }
 

--- a/src/components/ThinCard/ThinCardWidgetLabel.jsx
+++ b/src/components/ThinCard/ThinCardWidgetLabel.jsx
@@ -17,13 +17,12 @@ const ThinCardWidgetLabel = (props) => {
 }
 
 ThinCardWidgetLabel.defaultProps = {
-  style: {},
-  className: {}
+  style: {}
 }
 
 ThinCardWidgetLabel.propTypes = {
   style: PropTypes.object,
-  className: PropTypes.object
+  className: PropTypes.string
 }
 
 export default ThinCardWidgetLabel

--- a/src/components/ThinCard/ThinCardWidgetValue.jsx
+++ b/src/components/ThinCard/ThinCardWidgetValue.jsx
@@ -16,12 +16,11 @@ const ThinCardWidgetValue = (props) => {
   )
 }
 ThinCardWidgetValue.defaultProps = {
-  style: {},
-  className: {}
+  style: {}
 }
 
 ThinCardWidgetValue.propTypes = {
   style: PropTypes.object,
-  className: PropTypes.object
+  className: PropTypes.string
 }
 export default ThinCardWidgetValue


### PR DESCRIPTION
# problem statement
ThinCard components print warnings in dev mode when you pass them a `className` prop.
```
Warning: Failed prop type: Invalid prop `className` of type `string` supplied to `ThinCardWidgetLabel`, expected `object`.
    in ThinCardWidgetLabel (created by PreviewComponent)
    in PreviewComponent
    in Wrapper
```

# solution
Change the className prop type on those components to 'string' instead of 'object'.

# discussion
Other SUIR components define the className prop as being a string, so we should be consistent.

To test this, I added a className prop to each of these components and confirmed that I saw warnings about incorrect prop types, then confirmed that after I changed the PropTypes, they didn't print warnings anymore.