### PR TITLE
fix(ThinCard) Make expand button smaller

### DIFF
--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -10,8 +10,8 @@ const ThinCardDrawer = (props) => {
     <div {...externalAttributes}>
       {(!props.expanded) ? (
         <Flexbox className='drawer' flexDirection='row' onClick={props.expandGroupToggle}>
-          <Flexbox className='drawer__center' width='150px' paddingLeft='1em' paddingRight='1em'>
-            <Flexbox alignItems='center' className='drawer__center_copy' flexGrow={2}>EXPAND</Flexbox>
+          <Flexbox className='drawer__expand_button'>
+            <Flexbox alignItems='center' className='drawer__button' flexGrow={2}>EXPAND</Flexbox>
             <Flexbox><Icon className='ei arrow_carrot-down text-large' /></Flexbox>
           </Flexbox>
           <Flexbox className='drawer__side' flexGrow={3} />
@@ -21,8 +21,8 @@ const ThinCardDrawer = (props) => {
             {props.children}
             <Flexbox className='drawer' onClick={props.expandGroupToggle}>
 
-              <Flexbox className='drawer__center' width='100%' justifyContent='center' paddingLeft='1em' paddingRight='1em'>
-                <Flexbox alignItems='center' className='drawer__center_copy'>COLLAPSE</Flexbox>
+              <Flexbox className='drawer__collapse_button'>
+                <Flexbox alignItems='center' className='drawer__button'>COLLAPSE</Flexbox>
                 <Flexbox><Icon className='ei arrow_carrot-up text-large' /></Flexbox>
               </Flexbox>
 

--- a/src/styles/components/thin-card.css
+++ b/src/styles/components/thin-card.css
@@ -92,12 +92,24 @@
     background-color: #dbdee1;
     border-top: 3px solid var(--blue);
   }
-  & .drawer__center {
+  & .drawer__expand_button {
     background-color: var(--blue);
     border-bottom: 2px solid var(--blue);
     color: white;
+    width: 100px;
+    padding-left: 1em;
+    padding-right: 1em;
   }
-  & .drawer__center_copy {
+  & .drawer__collapse_button {
+    background-color: var(--blue);
+    border-bottom: 2px solid var(--blue);
+    color: white;
+    width: 100%;
+    justify-content: center;
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+  & .drawer__button {
     font-size: 12px;
   }
   & .text-large {


### PR DESCRIPTION
# problem statement
Expand button doesn't match mockups.

# solution
Shrink it down to 100px. Extract specific CSS classes for expand/collapse so we can easily tweak it in the future.

# discussion
**Before**
![expand_before](https://user-images.githubusercontent.com/564302/27058537-c7ba1572-4f86-11e7-9955-b651da73fb98.JPG)

**After**
![expand_after](https://user-images.githubusercontent.com/564302/27058451-2c73912e-4f86-11e7-8a30-879daadd646e.JPG)