### PR TITLE
fix(ThinCard): Left align collapse button

### DIFF
--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -19,13 +19,13 @@ const ThinCardDrawer = (props) => {
         ) : (
           <div>
             {props.children}
-            <Flexbox className='drawer' onClick={props.expandGroupToggle}>
+            <Flexbox className='drawer' flexDirection='row' onClick={props.expandGroupToggle}>
 
               <Flexbox className='drawer__collapse_button'>
-                <Flexbox alignItems='center' className='drawer__button'>COLLAPSE</Flexbox>
+                <Flexbox alignItems='center' className='drawer__button' flexGrow={2}>COLLAPSE</Flexbox>
                 <Flexbox><Icon className='ei arrow_carrot-up text-large' /></Flexbox>
               </Flexbox>
-
+              <Flexbox className='drawer__side_blue' flexGrow={3} />
             </Flexbox>
           </div>
         )

--- a/src/styles/components/thin-card.css
+++ b/src/styles/components/thin-card.css
@@ -92,6 +92,10 @@
     background-color: #dbdee1;
     border-top: 3px solid var(--blue);
   }
+  & .drawer__side_blue {
+    background-color: var(--blue);
+    border-top: 3px solid var(--blue);
+  }
   & .drawer__expand_button {
     background-color: var(--blue);
     border-bottom: 2px solid var(--blue);
@@ -104,8 +108,7 @@
     background-color: var(--blue);
     border-bottom: 2px solid var(--blue);
     color: white;
-    width: 100%;
-    justify-content: center;
+    width: 100px;
     padding-left: 1em;
     padding-right: 1em;
   }


### PR DESCRIPTION
# problem statement

The expand button on ThinCard is left aligned, but not the collapse button.

# solution

Make the collapse button left-aligned.

# discussion

Since we're left-aligning the expand button, we left-align the collapse button text as well. It still expands to fill the full width below the card, however.

![expand_left_align](https://user-images.githubusercontent.com/564302/27104648-ccb95a04-5041-11e7-886d-75006b32ea8f.JPG)

![collapse_left_align](https://user-images.githubusercontent.com/564302/27104652-ceefd9a6-5041-11e7-8724-beb0f3a86f05.JPG)
