### PR TITLE
fix(button) removed 'tripwire' from styles and markup and tweaked sty…

### DIFF
--- a/semantic/src/themes/tripwire/elements/button.overrides
+++ b/semantic/src/themes/tripwire/elements/button.overrides
@@ -3,46 +3,47 @@
 *******************************/
 
 
-.ui.tripwire.button {
+.ui.button {
   color: @grey;
   border: 2px solid #A6A8AB;
   background: @white;
   border-radius: 0px;
 }
 
-.ui.tripwire.button:active,
-.ui.tripwire.active.button:active {
+.ui.button:active,
+.ui.active.button:active {
   border-color: @blue;
   color: @white;
   background: @blue;
 }
-.ui.tripwire.active.button {
+.ui.active.button {
   border-color: @blue;
   color: @white;
   background: @blue;
 }
 
-.ui.tripwire.button:focus,
-.ui.tripwire.button:hover {
+.ui.button:focus,
+.ui.button:hover {
   border-color: @blue;
   color: @blue;
+  background: @white;
 }
-.ui.tripwire.button:active {
+.ui.button:active {
   border-color: @blue;
   color: @white;
   background: @blue;
 }
-.ui.tripwire.active.button {
+.ui.active.button {
   border-color: @blue;
   color: @white;
   background: @blue;
 }
-.ui.tripwire.active.button:hover {
+.ui.active.button:hover {
   border-color: @blue;
   color: @white;
   background: @blue;
 }
-.ui.tripwire.active.button:active {
+.ui.active.button:active {
   border-color: @blue;
   color: @white;
   background: @blue;
@@ -150,6 +151,7 @@
 .ui.icon.button {
   color: @grey;
   background: transparent;
+  border: 0;
 }
 .ui.icon.button:hover {
   color: @blue;

--- a/src/components/suir/button/Button.examples.md
+++ b/src/components/suir/button/Button.examples.md
@@ -1,24 +1,24 @@
 ## Generic
 
     const Button = require('semantic-ui-react').Button;
-    <Button className='tripwire'>Test button</Button>
+    <Button className=''>Test button</Button>
 
 ## Disabled Button
 
     const Button = require('semantic-ui-react').Button;
-    <Button className='tripwire' disabled >Some Copy </Button>
+    <Button className='' disabled >Some Copy </Button>
 
 ## Active Button
 
     const Button = require('semantic-ui-react').Button;
-    <Button className='tripwire' active>
+    <Button className='' active>
         Some Copy
     </Button>
 
 ## Positive Button
 
     const Button = require('semantic-ui-react').Button;
-    <Button positive className='tripwire'>
+    <Button positive className=''>
       <i className='icon_check' style={{marginRight: '10px'}} />
         Positive
       </Button>
@@ -26,7 +26,7 @@
 ## Negative Button
 
     const Button = require('semantic-ui-react').Button;
-    <Button negative className='tripwire'>
+    <Button negative className=''>
     <i className='icon_close' style={{marginRight: '10px'}} />
     Negative
     </Button>

--- a/src/components/suir/popup/Popup.examples.md
+++ b/src/components/suir/popup/Popup.examples.md
@@ -2,19 +2,19 @@
     const Button = require('semantic-ui-react').Button;
     <div>
         <Popup
-          trigger={<Button className='tripwire'>Popup Neutral</Button>}
+          trigger={<Button className=''>Popup Neutral</Button>}
           content='Neutral Popup Content'
           className='grey'
           positioning='bottom left' />
         <br /><br />
         <Popup
-            trigger={<Button className='tripwire'>Popup Critical</Button>}
+            trigger={<Button className=''>Popup Critical</Button>}
             content='Critical Popup Content'
             className='red'
             positioning='top right'/>
         <br /><br />
         <Popup
-            trigger={<Button className='tripwire'>Popup Warning</Button>}
+            trigger={<Button className=''>Popup Warning</Button>}
             content='Warning Popup Content'
             className='yellow'
             positioning='bottom left' />


### PR DESCRIPTION
…les to keep default intent #85

# problem statement

We are using the class "tripwire" in our default button themes. This is unnecessary for the default, and can lead to overly-high specificity requiring high levels of precedence and complex inheritance chains for future styles. 

# solution

1) Removed the class from CSS inheritance chains.
2) Added 'border:0' to remove border from icon-button.
Removing "tripwire" from the CSS resulted in the icon buttons receiving an override from the regular buttons (since icons didn't use tripwire previously and some specificity was lost).
3) Added 'background: white;' to buttons because without the extra specificity from .tripwire, the grey background from semanticUI was taking precedence.
4) Updated markup by removing 'tripwire' classes.

