### PR TITLE
fix(Radio): patch broken export

### DIFF
--- a/src/components/suir/radio/Radio.js
+++ b/src/components/suir/radio/Radio.js
@@ -1,2 +1,2 @@
-import Radio from 'semantic-ui-react/dist/commonjs/modules/Radio'
+import Radio from 'semantic-ui-react/dist/commonjs/addons/Radio/Radio'
 export default Radio


### PR DESCRIPTION
# problem statement

- attempting to use `Radio` fails!

# solution

- fix import path

# discussion

```
$ tree node_modules/semantic-ui-react/dist/commonjs/addons/Radio/
node_modules/semantic-ui-react/dist/commonjs/addons/Radio/
├── Radio.d.ts
├── Radio.js
├── index.d.ts
└── index.js

0 directories, 4 files
```