### PR TITLE
refactor(Button): make default button _actually_ default

### DIFF
--- a/semantic/src/themes/tripwire/elements/button.overrides
+++ b/semantic/src/themes/tripwire/elements/button.overrides
@@ -3,193 +3,48 @@
 *******************************/
 
 
+/* base colors */
 .ui.button {
-  color: @blue;
-  border: 2px solid @blue;
-  background: @white;
-  border-radius: 2px;
+  border: 2px solid;
+  border-color: @blue;
 }
 
-.ui.buttons .button:first-child,
-.ui.button.primary {
-  border: 2px solid @primaryColor;
-}
+.ui.button.red { border-color: @red; }
+.ui.button.orange { border-color: @orange; }
+.ui.button.yellow { border-color: @yellow; }
+.ui.button.olive { border-color: @olive; }
+.ui.button.green { border-color: @green; }
+.ui.button.teal { border-color: @teal; }
+.ui.button.blue { border-color: @blue; }
+.ui.button.violet { border-color: @violet; }
+.ui.button.purple { border-color: @purple; }
+.ui.button.pink { border-color: @pink; }
+.ui.button.brown { border-color: @brown; }
+.ui.button.grey { border-color: @grey; }
+.ui.button.black { border-color: @black; }
 
-.ui.button.primary:hover {
-  border-color: @primaryColorHover;
-}
-
+/* focus */
 .ui.button:focus {
-  border-color: @blue;
-  color: @blue;
-  background: @white;
   box-shadow: @focusedButtonShadow;
 }
 
-.ui.button:hover {
-  border-color: @blue;
-  color: @invertedTextColor;
-  background: @blue;
-}
+/* hover */
 
-.ui.button:active,
-.ui.active.button:active,
-.ui.active.button {
-  border-color: @blue;
-  color: @invertedTextColor;
-  background: @blue;
-  box-shadow: @focusedButtonShadow;
-}
+.ui.button.red { border-color: @red; }
+.ui.button.orange { border-color: @orange; }
+.ui.button.yellow { border-color: @yellow; }
+.ui.button.olive { border-color: @olive; }
+.ui.button.green { border-color: @green; }
+.ui.button.teal { border-color: @teal; }
+.ui.button.blue { border-color: @blue; }
+.ui.button.violet { border-color: @violet; }
+.ui.button.purple { border-color: @purple; }
+.ui.button.pink { border-color: @pink; }
+.ui.button.brown { border-color: @brown; }
+.ui.button.grey { border-color: @grey; }
+.ui.button.black { border-color: @black; }
+.ui.button.positive { border-color: @positiveColor; }
+.ui.button.negative { border-color: @negativeColor; }
 
-.ui.active.button:hover {
-  border-color: @blue;
-  color: @invertedTextColor;
-  background: @blue;
-}
-.ui.active.button:active {
-  border-color: @blue;
-  color: @invertedTextColor;
-  background: @blue;
-  box-shadow: @focusedButtonShadow;
-}
-
-.ui.disabled.button {
-  background-color: @white;
-  border-color: @genericDisabledBorder;
-  color: @disabledText;
-  opacity: 100 !important;
-}
-
-/*---------------
-    Positive
-----------------*/
-
-/* Standard */
-.ui.positive.buttons .button,
-.ui.positive.button {
-  background-color: @blue;
-  border-color: @blue;
-  color: @invertedTextColor;
-  text-shadow: @positiveTextShadow;
-  background-image: @coloredBackgroundImage;
-}
-
-.ui.buttons .ui.positive.button:first-child {
-  border-style: solid;
-  border-width: 2px;
-}
-
-.ui.positive.button {
-  box-shadow: @coloredBoxShadow;
-}
-.ui.positive.buttons .button:focus,
-.ui.positive.button:focus {
-  background-color: @blue;
-  border-color: @blue;
-  color: @invertedTextColor;
-  text-shadow: @positiveTextShadow;
-  box-shadow: @focusedButtonShadow;
-}
-.ui.positive.buttons .button:hover,
-.ui.positive.button:hover {
-  background-color: @primaryColorHover;
-  border-color: @primaryColorHover;
-  color: @invertedTextColor;
-  text-shadow: @positiveTextShadow;
-}
-.ui.positive.buttons .button:active,
-.ui.positive.button:active,
-.ui.positive.buttons .active.button,
-.ui.positive.buttons .active.button:active,
-.ui.positive.active.button,
-.ui.positive.button .active.button:active {
-  background-color: @primaryColorHover;
-  border-color: @primaryColorHover;
-  color: @invertedTextColor;
-  text-shadow: @positiveTextShadow;
-  box-shadow: @focusedButtonShadow;
-}
-
-.ui.positive.disabled.button {
-  background-color: @positiveDisabledBackground;
-  border-color: @positiveDisabledBackground;
-  color: @disabledText;
-  opacity: 100 !important;
-}
-
-/*---------------
-     Negative
-----------------*/
-
-/* Standard */
-.ui.negative.buttons .button,
-.ui.negative.button {
-  background: @white;
-  color: @negativeTextColor;
-  border: 2px solid @negativeBorder;
-  text-shadow: @negativeTextShadow;
-  background-image: @coloredBackgroundImage;
-}
-.ui.negative.button {
-  box-shadow: @coloredBoxShadow;
-}
-.ui.buttons .ui.negative.button:first-child {
-  border: 2px solid @negativeBorder;
-}
-.ui.negative.buttons .button:focus,
-.ui.negative.button:focus {
-  background: @white;
-  color: @negativeTextColor;
-  border: 2px solid @negativeBorder;
-  text-shadow: @negativeTextShadow;
-  background-image: @coloredBackgroundImage;
-  box-shadow: @focusedButtonShadow;
-}
-.ui.negative.buttons .button:hover,
-.ui.negative.button:hover,
-.ui.buttons .ui.negative.button:hover:first-child {
-  background: @negativeInverted;
-  color: @invertedTextColor;
-  border: 2px solid @negativeInverted;
-  text-shadow: @negativeTextShadow;
-}
-.ui.negative.buttons .button:active,
-.ui.negative.button:active,
-.ui.negative.buttons .active.button,
-.ui.negative.buttons .active.button:active,
-.ui.negative.active.button,
-.ui.negative.button .active.button:active {
-  background: #999999;
-  color: @invertedTextColor;
-  border: 2px solid @negativeInverted;
-  text-shadow: @negativeTextShadow;
-  box-shadow: @focusedButtonShadow;
-}
-
-.ui.negative.disabled.button {
-  background-color: @white;
-  border-color: @negativeDisabledBorder;
-  color: @disabledText;
-  opacity: 100 !important;
-}
-
-/*--------------
-     Icon
----------------*/
-
-.ui.icon.button {
-  color: @grey;
-  background: transparent;
-  border: 0;
-}
-.ui.icon.button:hover {
-  color: @blue;
-  background: transparent;
-}
-.ui.icon.button:active,
-.ui.icon.button .ui.active.button,
-.ui.icon.button.ui.active.button{
-  color: @blue;
-  background: transparent;
-}
+/* active */
 

--- a/semantic/src/themes/tripwire/elements/button.variables
+++ b/semantic/src/themes/tripwire/elements/button.variables
@@ -9,7 +9,7 @@
 /* Button */
 @verticalMargin: 0em;
 @horizontalMargin: 0.8em;
-@backgroundColor: #E0E1E2;
+@backgroundColor: @white;
 @backgroundImage: none;
 @background: @backgroundColor @backgroundImage;
 @lineHeight: 1em;
@@ -23,10 +23,10 @@
 @tapColor: transparent;
 @fontFamily: @pageFont;
 @fontWeight: 400;
-@textColor: rgba(0, 0, 0, 0.6);
+@textColor: @blue;
 @textShadow: none;
 @invertedTextShadow: @textShadow;
-@borderRadius: 0px;
+@borderRadius: 2px;
 @verticalAlign: baseline;
 
 /* Internal Shadow */
@@ -84,17 +84,17 @@
 --------------------*/
 
 /* Hovered */
-@hoverBackgroundColor: #999;
+@hoverBackgroundColor: @blue;
 @hoverBackgroundImage: @backgroundImage;
 @hoverBoxShadow: @boxShadow;
-@hoverColor: @hoveredTextColor;
+@hoverColor: @white;
 @iconHoverOpacity: 0.85;
 
 /* Focused */
 @focusBackgroundColor: @hoverBackgroundColor;
 @focusBackgroundImage: '';
 @focusBoxShadow: '';
-@focusColor: @hoveredTextColor;
+@focusColor: @white;
 @iconFocusOpacity: 0.85;
 
 /* Disabled */
@@ -102,25 +102,25 @@
 @disabledBoxShadow: none;
 
 /* Pressed Down */
-@downBackgroundColor: #BABBBC;
+@downBackgroundColor: darken(@blue, 20%);
 @downBackgroundImage: '';
 @downPressedShadow: none;
 @downBoxShadow:
   @borderBoxShadow,
   @downPressedShadow
 ;
-@downColor: @pressedTextColor;
+@downColor: @white;
 
 /* Active */
-@activeBackgroundColor: #C0C1C2;
+@activeBackgroundColor: darken(@blue, 10%);
 @activeBackgroundImage: none;
-@activeColor: @selectedTextColor;
+@activeColor: @white;
 @activeBoxShadow: @borderBoxShadow;
 
 /* Active + Hovered */
-@activeHoverBackgroundColor: @activeBackgroundColor;
+@activeHoverBackgroundColor: @blue;
 @activeHoverBackgroundImage: none;
-@activeHoverColor: @activeColor;
+@activeHoverColor: @white;
 @activeHoverBoxShadow: @activeBoxShadow;
 
 /* Loading */
@@ -233,7 +233,7 @@ which ends out being a hard edged box rather than the slightly blurred outline
 
 /* Basic Down */
 @basicDownBackground: #F8F8F8;
-@basicDownTextColor: @pressedTextColor;
+@basicDownTextColor: @white;
 @basicDownBoxShadow:
   0px 0px 0px @basicBorderSize rgba(0, 0, 0, 0.15) inset,
   0px 1px 4px 0px @borderColor inset
@@ -262,7 +262,7 @@ which ends out being a hard edged box rather than the slightly blurred outline
 
 
 /* Basic Group */
-@basicGroupBorder: @basicBorderSize solid @borderColor;
+@basicGroupBorder: 0;
 @basicGroupBoxShadow: none;
 
 /*-------------------
@@ -354,7 +354,7 @@ which ends out being a hard edged box rather than the slightly blurred outline
 @positiveDisabledBackground: #ebebeb;
 
 @negativeBackgroundImage: @coloredBackgroundImage;
-@negativeTextColor: #454545;
+@negativeTextColor: @white;
 @negativeTextShadow: @invertedTextShadow;
 @negativeBoxShadow: @coloredBoxShadow;
 

--- a/src/components/suir/button/Button.examples.md
+++ b/src/components/suir/button/Button.examples.md
@@ -1,28 +1,3 @@
-## Positive Button
-
-    const Button = require('semantic-ui-react').Button;
-    <div>
-      <Button positive className=''>Positive</Button>
-      <Button positive className=''>
-        <i className='icon_check' style={{marginRight: '10px'}} />
-        Positive with Icon
-      </Button>
-      <Button positive active className=''>Positive Active</Button>
-      <Button positive disabled className=''>Positive Disabled</Button>
-    </div>
-
-## Negative Button
-
-    const Button = require('semantic-ui-react').Button;
-    <div>
-      <Button negative className=''>
-        <i className='icon_close' style={{marginRight: '10px'}} />
-        Negative
-      </Button>
-      <Button negative active className=''>Negative Active</Button>
-      <Button negative disabled className=''>Negative Disabled</Button>
-    </div>
-
 ## Generic
 
     const Button = require('semantic-ui-react').Button;
@@ -30,6 +5,50 @@
       <Button className=''>Generic</Button>
       <Button active className=''>Generic Active</Button>
       <Button disabled className=''>Generic Disabled</Button>
+    </div>
+
+## Primary
+
+    const Button = require('semantic-ui-react').Button;
+    <div>
+      <Button primary className=''>Primary</Button>
+      <Button primary active className=''>Primary Active</Button>
+      <Button primary disabled className=''>Primary Disabled</Button>
+    </div>
+
+## Secondary
+
+    const Button = require('semantic-ui-react').Button;
+    <div>
+      <Button secondary className=''>Secondary</Button>
+      <Button secondary active className=''>Secondary Active</Button>
+      <Button secondary disabled className=''>Secondary Disabled</Button>
+    </div>
+
+## Positive Button
+
+    const Button = require('semantic-ui-react').Button;
+    <div>
+      <Button positive className=''>Positive</Button>
+      <Button positive active className=''>Positive Active</Button>
+      <Button positive disabled className=''>Positive Disabled</Button>
+      <Button positive className=''>
+        <i className='icon_check' style={{marginRight: '10px'}} />
+        Positive with Icon
+      </Button>
+    </div>
+
+## Negative Button
+
+    const Button = require('semantic-ui-react').Button;
+    <div>
+      <Button negative className=''>Negative</Button>
+      <Button negative active className=''>Negative Active</Button>
+      <Button negative disabled className=''>Negative Disabled</Button>
+      <Button negative className=''>
+        <i className='icon_close' style={{marginRight: '10px'}} />
+        Negative with Icon
+      </Button>
     </div>
 
 ## Button Groups
@@ -69,34 +88,6 @@
       </div>
     </div>
 
-## Test
-
-    const Button = require('semantic-ui-react').Button;
-    <div>
-      <div>
-          <Button>Generic </Button>
-          <Button disabled>Generic disabled</Button>
-      </div>
-      <p />
-      <div>
-          <Button positive>Positive </Button>
-          <Button positive disabled>Positive disabled</Button>
-      </div>
-      <p />
-      <div>
-          <Button negative>Negative </Button>
-          <Button negative disabled>Negative disabled</Button>
-      </div>
-    </div>
-
-
-## Active Button
-
-    const Button = require('semantic-ui-react').Button;
-    <Button className='' active>
-        Some Copy
-    </Button>
-
 ## Icon Button
 
     const Button = require('semantic-ui-react').Button;
@@ -128,6 +119,27 @@
       <Button>Good Button</Button>
       <Button color='red'>Best Button</Button>
       <Button color='purple'>!! OMG FAVORITE Button !!</Button>
+    </div>
+
+## Color Buttons
+
+    const Button = require('semantic-ui-react').Button;
+    <div>
+      <Button color='red'>red</Button>
+      <Button color='orange'>orange</Button>
+      <Button color='yellow'>yellow</Button>
+      <Button color='olive'>olive</Button>
+      <Button color='green'>green</Button>
+      <Button color='teal'>teal</Button>
+      <Button color='blue'>blue</Button>
+      <Button color='violet'>violet</Button>
+      <Button color='purple'>purple</Button>
+      <Button color='pink'>pink</Button>
+      <Button color='brown'>brown</Button>
+      <Button color='grey'>grey</Button>
+      <Button color='black'>black</Button>
+      <Button color='positive'>positive</Button>
+      <Button color='negative'>negative</Button>
     </div>
 
 See full input documentation [here](http://react.semantic-ui.com/elements/button)


### PR DESCRIPTION
# problem statement

- theme doesn't allow colored buttons
  - a negative button is not red, but has default colors
  - a red button is part red, part blue

# solution

- remove most of the overrides
- refactor the button theme to use our default button styles as... the default button styles
- refine example set (expand goodies, drop redundants)

# discussion

- we've discussed this many times before ad-hoc, but i now have a stronger opinion on some of these color categories.  the theme gives us:

1. default
1. primary
1. secondary
1. positive
1. negative

we had patched positive/negative to be blue/gray instead of green/red.  while that was ok for buttons, positive/negative has global variables which we squashed.  if we think other positive/negative things (like warnings/alerts/text/etc) also make sense to always be blue/gray, fine, however, i'd wager that most likely blue/gray doesn't have universal appeal for these contexts.

with that, i propose that we:

1. dont use positive negative buttons at all, or
1. use them, but use them w/ green reds

and always use the more conventional primary/secondary/default buttons in most contexts

i'll probably have to organize a meeting for this :).
