### PR TITLE
fix(deps): Move react into a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "postcss-import": "^10.0.0",
     "postcss-loader": "^2.0.6",
     "postcss-neat": "^2.5.3",
+    "react": "^15 || ^16",
+    "react-dom": "^15 || ^16",
     "react-remarkable": "^1.1.1",
     "react-styleguidist": "^5.2.1",
     "react-test-renderer": "^15.5.4",
@@ -64,14 +66,16 @@
     "webpack": "^3.5.6"
   },
   "dependencies": {
-    "d3": "^4.7.1",
+    "d3": "^4.11.0",
     "elegant-icons": "^0.0.1",
-    "flexbox-react": "^4.3.3",
+    "flexbox-react": "^4.4.0",
     "lato-font": "^2.0.0",
-    "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "semantic-ui-react": "^0.72.0"
+    "prop-types": "^15.6.0",
+    "semantic-ui-react": "^0.74.2"
+  },
+  "peerDependencies": {
+    "react": "^15 || ^16",
+    "react-dom": "^15 || ^16"
   },
   "scripts": {
     "build": "node scripts/build",

--- a/src/components/charts/AreaChart/AreaChart.jsx
+++ b/src/components/charts/AreaChart/AreaChart.jsx
@@ -72,7 +72,7 @@ class AreaChart extends React.Component {
                 <g key={index}>
                   <polygon fill='#A676B2' points='38,-3 34,1 42,1' />
                   <text>
-                    <tspan className={type} is text-anchor='middle' x='58px' y='2px' font-size='11px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
+                    <tspan className={type} textAnchor='middle' x='58px' y='2px' fontSize='11px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
                   </text>
                 </g>
               )
@@ -81,7 +81,7 @@ class AreaChart extends React.Component {
                 <g key={index}>
                   <polygon fill='#A676B2' points='38,17 34,13 42,13' />
                   <text>
-                    <tspan className={type} is text-anchor='middle' x='60px' y='18px' font-size='11px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
+                    <tspan className={type} textAnchor='middle' x='60px' y='18px' fontSize='11px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
                   </text>
                 </g>
               )
@@ -89,7 +89,7 @@ class AreaChart extends React.Component {
             return (
               <g key={index}>
                 <text>
-                  <tspan className={type} is text-anchor='middle' x='-20px' y='15px' font-size='28px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
+                  <tspan className={type} textAnchor='middle' x='-20px' y='15px' fontSize='28px' fill='#A676B2'>{this.state.tooltip.data[type]}</tspan>
                 </text>
               </g>
             )

--- a/src/components/charts/AreaChart/ToolTip.jsx
+++ b/src/components/charts/AreaChart/ToolTip.jsx
@@ -29,15 +29,16 @@ const ToolTip = (props) => {
   return (
     <g transform={transform}>
       <polygon
-        class='shadow'
-        is points='10,0  30,0  20,10'
+        className='shadow'
+        points='10,0  30,0  20,10'
         transform={transformArrow}
         fill='#ffffff' opacity='1'
         stroke='#A676B2'
-        stroke-width='1px'
+        strokeWidth='1px'
         visibility={visibility}
       />
-      <rect class='shadow' is width={width} height={height} rx='0' ry='0' visibility={visibility} fill='#ffffff' stroke='#A676B2' stroke-width='1px' />
+      <rect className='shadow' width={width} height={height} rx='0' ry='0' visibility={visibility}
+        fill='#ffffff' stroke='#A676B2' strokeWidth='1px' />
       {/* we want tooltip content a little flexible by allow passing direct from whatever call Tooltip */}
       <g visibility={visibility} transform={transformText}>
         {props.children}

--- a/src/components/charts/BarChart/BarChartTooltip.jsx
+++ b/src/components/charts/BarChart/BarChartTooltip.jsx
@@ -23,28 +23,27 @@ const ToolTip = (props) => {
   return (
     <g transform={transform} pointerEvents='none'>
       <polygon
-        class='shadow'
-        is points='10,0  30,0  20,10'
+        className='shadow'
+        points='10,0  30,0  20,10'
         transform={transformArrow}
         fill='#ffffff'
         opacity='1'
-        stroke-width='2px'
+        strokeWidth='2px'
         stroke={props.tooltip.color}
         visibility={visibility}
       />
 
       <rect
         width={width}
-        is
         height={height}
         rx='0'
         ry='0'
         visibility={visibility}
         fill='#ffffff'
         opacity='1'
-        stroke-opacity='1'
+        strokeOpacity='1'
         stroke={props.tooltip.color}
-        stroke-width='2px'
+        strokeWidth='2px'
       />
       <line
         visibility={visibility}
@@ -52,16 +51,15 @@ const ToolTip = (props) => {
         y1='0'
         x2='27'
         y2='0'
-        is
         opacity='1'
-        stroke-opacity='1'
+        strokeOpacity='1'
         stroke='white'
-        stroke-width='3px'
+        strokeWidth='3px'
         transform={transformLine}
       />
-      <text is visibility={visibility} transform={transformText} >
-        <tspan is x='0' y='10' text-anchor='left' font-size='12px' fill='#657d8e'>{`${props.tooltip.title} (${props.tooltip.data.value})`}</tspan>
-        <tspan is x='0' y='20' text-anchor='left' dy='12px' font-size='12px' fill='#657d8e'>{props.tooltip.data.key}</tspan>
+      <text visibility={visibility} transform={transformText} >
+        <tspan x='0' y='10' textAnchor='left' fontSize='12px' fill='#657d8e'>{`${props.tooltip.title} (${props.tooltip.data.value})`}</tspan>
+        <tspan x='0' y='20' textAnchor='left' dy='12px' fontSize='12px' fill='#657d8e'>{props.tooltip.data.key}</tspan>
       </text>
 
     </g>


### PR DESCRIPTION
== DETAILS

We were depending on react directly and exposing this as a dependency for client apps.  This changeset moves react over to be a peer dependency.

Also fixed a number of noisy svg warnings where we weren't correctly using jxs compatible svg attribute names even though we were embedding them in jsx code.

== TESTS

Manual in the sylist page.

