### PR TITLE
Upgraded Lato Fonts to version 3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "d3": "^4.11.0",
     "elegant-icons": "^0.0.1",
     "flexbox-react": "^4.4.0",
-    "lato-font": "^2.0.0",
+    "lato-font": "^3.0.0",
     "prop-types": "^15.6.0",
     "semantic-ui-less": "^2.2.12",
     "semantic-ui-react": "^0.74.2"

--- a/src/semantic-ui-theme/themes/tripwire/globals/site.overrides
+++ b/src/semantic-ui-theme/themes/tripwire/globals/site.overrides
@@ -8,153 +8,132 @@
 /* Lato (hairline, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-hairline/lato-hairline.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-hairline/lato-hairline.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-hairline/lato-hairline.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-hairline/lato-hairline.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-hairline/lato-hairline.woff") format("woff");
   font-weight: 100;
   font-style: normal;
 }
 /* Lato (hairline, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-hairline-italic/lato-hairline-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-hairline-italic/lato-hairline-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-hairline-italic/lato-hairline-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-hairline-italic/lato-hairline-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-hairline-italic/lato-hairline-italic.woff") format("woff");
   font-weight: 100;
   font-style: italic;
 }
 /* Lato (thin, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-thin/lato-thin.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-thin/lato-thin.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-thin/lato-thin.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-thin/lato-thin.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-thin/lato-thin.woff") format("woff");
   font-weight: 200;
   font-style: normal;
 }
 /* Lato (thin, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-thin-italic/lato-thin-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-thin-italic/lato-thin-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-thin-italic/lato-thin-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-thin-italic/lato-thin-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-thin-italic/lato-thin-italic.woff") format("woff");
   font-weight: 200;
   font-style: italic;
 }
 /* Lato (light, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-light/lato-light.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-light/lato-light.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-light/lato-light.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-light/lato-light.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-light/lato-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
 /* Lato (light, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-light-italic/lato-light-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-light-italic/lato-light-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-light-italic/lato-light-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-light-italic/lato-light-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-light-italic/lato-light-italic.woff") format("woff");
   font-weight: 300;
   font-style: italic;
 }
 /* Lato (normal, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-normal/lato-normal.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-normal/lato-normal.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-normal/lato-normal.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-normal/lato-normal.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-normal/lato-normal.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 /* Lato (normal, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-normal-italic/lato-normal-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-normal-italic/lato-normal-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-normal-italic/lato-normal-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-normal-italic/lato-normal-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-normal-italic/lato-normal-italic.woff") format("woff");
   font-weight: 400;
   font-style: italic;
 }
 /* Lato (medium, regular) */
 @font-face {
   font-family: "Lato Medium";
-  src: url("themes/tripwire/assets/fonts/lato/lato-medium/lato-medium.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-medium/lato-medium.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-medium/lato-medium.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-medium/lato-medium.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-medium/lato-medium.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 /* Lato (medium, italic) */
 @font-face {
   font-family: "Lato Medium";
-  src: url("themes/tripwire/assets/fonts/lato/lato-medium-italic/lato-medium-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-medium-italic/lato-medium-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-medium-italic/lato-medium-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-medium-italic/lato-medium-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-medium-italic/lato-medium-italic.woff") format("woff");
   font-weight: 400;
   font-style: italic;
 }
 /* Lato (semibold, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-semibold/lato-semibold.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-semibold/lato-semibold.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-semibold/lato-semibold.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-semibold/lato-semibold.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-semibold/lato-semibold.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
 /* Lato (semibold, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-semibold-italic/lato-semibold-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-semibold-italic/lato-semibold-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-semibold-italic/lato-semibold-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-semibold-italic/lato-semibold-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-semibold-italic/lato-semibold-italic.woff") format("woff");
   font-weight: 500;
   font-style: italic;
 }
 /* Lato (bold, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-bold/lato-bold.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-bold/lato-bold.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-bold/lato-bold.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-bold/lato-bold.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-bold/lato-bold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 /* Lato (bold, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-bold-italic/lato-bold-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-bold-italic/lato-bold-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-bold-italic/lato-bold-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-bold-italic/lato-bold-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-bold-italic/lato-bold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
 /* Lato (heavy, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-heavy/lato-heavy.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-heavy/lato-heavy.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-heavy/lato-heavy.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-heavy/lato-heavy.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-heavy/lato-heavy.woff") format("woff");
   font-weight: 800;
   font-style: normal;
 }
 /* Lato (heavy, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-heavy-italic/lato-heavy-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-heavy-italic/lato-heavy-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-heavy-italic/lato-heavy-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-heavy-italic/lato-heavy-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-heavy-italic/lato-heavy-italic.woff") format("woff");
   font-weight: 800;
   font-style: italic;
 }
 /* Lato (black, regular) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-black/lato-black.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-black/lato-black.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-black/lato-black.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-black/lato-black.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-black/lato-black.woff") format("woff");
   font-weight: 900;
   font-style: normal;
 }
 /* Lato (black, italic) */
 @font-face {
   font-family: Lato;
-  src: url("themes/tripwire/assets/fonts/lato/lato-black-italic/lato-black-italic.eot");
-  src: url("themes/tripwire/assets/fonts/lato/lato-black-italic/lato-black-italic.eot?#iefix") format("embedded-opentype"), url("themes/tripwire/assets/fonts/lato/lato-black-italic/lato-black-italic.woff") format("woff"), url("themes/tripwire/assets/fonts/lato/lato-black-italic/lato-black-italic.ttf") format("truetype");
+  src: url("themes/tripwire/assets/fonts/lato/lato-black-italic/lato-black-italic.woff") format("woff");
   font-weight: 900;
   font-style: italic;
 }
 @font-face {
 	font-family: 'ElegantIcons';
-	src:url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.eot');
-	src:url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.eot?#iefix') format('embedded-opentype'),
-		url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.woff') format('woff'),
-		url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.ttf') format('truetype'),
+	src: url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.woff') format('woff'),
 		url('themes/tripwire/assets/fonts/elegant-icons/ElegantIcons.svg#ElegantIcons') format('svg');
 	font-weight: normal;
 	font-style: normal;


### PR DESCRIPTION
    V3 only supports .woff and .woff 2 which are supported by all modern browsers and are more efficient than .eot and .ttf
    1) updated package.json
    2) removed all references to .ttf and .eot in .overrides files
