### PR TITLE
Fixed Hover Colors on Thin Card

### DIFF
--- a/src/components/ThinCard/ThinCard.examples.md
+++ b/src/components/ThinCard/ThinCard.examples.md
@@ -29,6 +29,30 @@ Richer Example
         </ThinCard.Widget>
       </ThinCard>
 
+Richer Example (Expanded)
+
+    <ThinCard data={{id: 0}} folder expanded={true} drawer={<ThinCard.Drawer expanded={true}><div style={{padding: '10px'}}>test</div></ThinCard.Drawer>}>
+        <ThinCard.PrimaryAction><StopStartButton /></ThinCard.PrimaryAction>
+        <ThinCard.Title>I'm ready to go!</ThinCard.Title>
+        <ThinCard.ActionButton>MANAGE</ThinCard.ActionButton>
+        <ThinCard.Widget borderLeft>
+          <ThinCard.Widget.Label style={{marginRight: '30px'}}>
+            LABEL
+          </ThinCard.Widget.Label>
+          <ThinCard.Widget.Value>
+            1234
+          </ThinCard.Widget.Value>
+        </ThinCard.Widget>
+        <ThinCard.Widget borderLeft>
+          <ThinCard.Widget.Label style={{marginRight: '30px'}}>
+            FOO
+          </ThinCard.Widget.Label>
+          <ThinCard.Widget.Value>
+            BAR
+          </ThinCard.Widget.Value>
+        </ThinCard.Widget>
+      </ThinCard>
+
 #### Supported Fragments ####
 
 ```javascript

--- a/src/styles/components/thin-card.css
+++ b/src/styles/components/thin-card.css
@@ -87,6 +87,17 @@
   }
   & .drawer {
     cursor: pointer;
+    &:hover {
+      & .drawer__side {
+        border-color: var(--denimblue);
+      }
+      & .drawer__expand_button,
+      & .drawer__collapse_button,
+      & .drawer__side_blue {
+        background-color: var(--denimblue);
+        border-color: var(--denimblue);
+      }
+    }
   }
   & .drawer__side {
     background-color: #dbdee1;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,11 +1,13 @@
 :root {
   --warningred: #c0382b;
   --warningyellow: #ff9e2c;
+  --lightblue: #bde9ff;
+  --darkblue: #586A7A;
   --blue: #3498db;
+  --denimblue: #1c75bd;
   --twgray: var(--darkblue);
   --textPurple: var(--purple);
   --black: #272F34;
-  --darkblue: #586A7A;
   --darkgray: #777776;
   --gray: #A6A8AB;
   --lightgray: #E5E6E7;
@@ -24,7 +26,6 @@
   --buttonBorder: #BBBDBF;
   --buttonActiveColor: white;
   --taggray: #ededed;
-  --lightblue: #bde9ff;
   --textGray: #657d8e;
   --base-border-radius: 0;
 }


### PR DESCRIPTION
# problem statement

Thin card button hover has wrong colors for hover.

The thin card expand and collapse buttons should have hover colors that match those used in the primary button.

This will entail changing how the draw color to the right of the collapse button is handled since it is separate and captures it's own hover events and we don't want there to be a split between the two segments in that panel.

# solution

Get correct color from UX Pin. Update variable w/ hexcode and use variable (no hexcodes in the css styles).

closes #122 