### PR TITLE
fix(button): Fix the borders on the icon button. Currently they appear to overlap

### DIFF
--- a/src/semantic-ui-theme/themes/tripwire/elements/button.overrides
+++ b/src/semantic-ui-theme/themes/tripwire/elements/button.overrides
@@ -181,6 +181,7 @@
   color: @grey;
   background: transparent;
   border: 0;
+  margin: .4em .8em .4em .8em;
 }
 .ui.icon.button:hover {
   color: @blue;


### PR DESCRIPTION
# problem statement
Icon box-shadows overlap if they're both active. Meh. But we can fix it easily.

# solution

Let's standardize the margins based on the existing right margin (.8em) by adding top .4em and bottom .4em.

closes #117