### PR TITLE
fix(tests): bump snapjerk s.t. html reports dont use bogus pathing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21631,9 +21631,9 @@
       "dev": true
     },
     "snapjerk": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/snapjerk/-/snapjerk-0.2.15.tgz",
-      "integrity": "sha512-rXotu7PIwHlODxYfpAUxtPvXrH2+VHFsqO79FNMvlC/zye3uuYXff7K6nU7qF/L5ezZrcUNA0jJnNNfLrvbrFg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/snapjerk/-/snapjerk-0.2.19.tgz",
+      "integrity": "sha512-rPUNQ8XhGXnI/cgUBhpwVzNYDT2xKC4bCSJoP8i8BsT6PJbI+VdhfCYzlQuCdjPdhADfrZ+pEdEvkm0CrXvYmA==",
       "dev": true,
       "requires": {
         "debug": "3.1.0",
@@ -21641,8 +21641,8 @@
         "fs-extra": "4.0.2",
         "meow": "3.7.0",
         "perish": "1.0.1",
-        "webjerk": "0.2.9",
-        "webjerk-snaps": "0.2.15"
+        "webjerk": "0.2.18",
+        "webjerk-snaps": "0.2.19"
       },
       "dependencies": {
         "debug": {
@@ -23702,9 +23702,9 @@
       "dev": true
     },
     "webjerk": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/webjerk/-/webjerk-0.2.9.tgz",
-      "integrity": "sha512-FaHkmw9TfnUtcqmPwg0rCOh+Qwq2IBdP7/19F+enlksSPScprNYq1u1yx7+0gnCbeXkGM9ccJALDc98AM8uwyQ==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/webjerk/-/webjerk-0.2.18.tgz",
+      "integrity": "sha512-X0SvDr4PmXgBlX55Z75Nh6FMnc8OuETkYJqG9+VSATU7uKll5Zd7F+ahHK0cDoaCQ1o5HyQHT5P2bvfBHuKCMQ==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -23713,9 +23713,9 @@
       }
     },
     "webjerk-image-set-diff": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/webjerk-image-set-diff/-/webjerk-image-set-diff-0.2.15.tgz",
-      "integrity": "sha512-XBDuIY8+6gcj7z5NkH3M5NXYqy6fob6Z2dvTfdUdIw/pEX9rOf0zKXxP2EDeutHXsWlSX4nL4fZ389YDT2vEWA==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/webjerk-image-set-diff/-/webjerk-image-set-diff-0.2.19.tgz",
+      "integrity": "sha512-Ny6ZyJxi7aZMMafcOWWekBKO5H2kspcpKKZxQKeXWCjiaF5N0MLre0HowndsnEZI7Yk9KpmVyo+DZgvOMqCcog==",
       "dev": true,
       "requires": {
         "blink-diff": "1.0.13",
@@ -23723,7 +23723,7 @@
         "debug": "3.1.0",
         "fs-extra": "4.0.2",
         "lodash": "4.17.4",
-        "webjerk-image-set-diff-reporter": "0.2.12"
+        "webjerk-image-set-diff-reporter": "0.2.19"
       },
       "dependencies": {
         "debug": {
@@ -23738,9 +23738,9 @@
       }
     },
     "webjerk-image-set-diff-reporter": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/webjerk-image-set-diff-reporter/-/webjerk-image-set-diff-reporter-0.2.12.tgz",
-      "integrity": "sha512-Ye/uv1+V+L4vzOXB87Ry21B04LSSEhyMxWYDW8NJqPXeIB9nLAMqj6gQ9sHdVYUTUjHuMDozdHpDYaiQbDgiPg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/webjerk-image-set-diff-reporter/-/webjerk-image-set-diff-reporter-0.2.19.tgz",
+      "integrity": "sha512-0/w6q4SzUsBCpNuG3k9na3aIXUjceu919oL9s5faOqDkme0bDiDjIwLd3hZJmwL+giuXQFSCROddkWT3N+1WCA==",
       "dev": true,
       "requires": {
         "axios": "0.16.2",
@@ -23766,16 +23766,16 @@
       }
     },
     "webjerk-snaps": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/webjerk-snaps/-/webjerk-snaps-0.2.15.tgz",
-      "integrity": "sha512-zpRaxZKHfvQQ4+wIQpzszRnq+guOr5RMQlzakFZ6MmjR7VDCXXD8zt8amm6E/ekkbAGyd4g0zqmD1bTwqN8V9w==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/webjerk-snaps/-/webjerk-snaps-0.2.19.tgz",
+      "integrity": "sha512-0NYgBt1/WTMt31E5wbBHMuc2YGOVK3iAd9/NdWTFtaAR1AcSi/N+dQoWrQALoo0Lji09I0XEKxh8R1z7Sj/HaQ==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
         "fs-extra": "4.0.2",
         "lodash": "4.17.4",
-        "webjerk-image-set-diff": "0.2.15",
+        "webjerk-image-set-diff": "0.2.19",
         "webjerk-snaps-adapter-puppeteer": "0.2.15"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rucksack-css": "^1.0.2",
     "semantic-release": "^6.3.2",
     "semantic-release-cli": "^3.0.2",
-    "snapjerk": "^0.2.15",
+    "snapjerk": "^0.2.19",
     "standard": "^10.0.3",
     "style-loader": "^0.18.2",
     "url": "^0.11.0",


### PR DESCRIPTION
# problem statement

- old version of `snapjerk` doesn't generate reports correctly.

# solution

- new version of snapjerk generates reports with asset paths correct

# discussion

- this was intended to go in with #138, but was stale on my machine
- given this is a strict dep update on a minor flag, i will eager merge on test pass, against normal biz process
  - we should consider updating CONTRIBUTING.md to allow for minor/patch dep updates and **strict** doc updates to be eager merged by project owners