### PR TITLE
Feat/send static site from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             echo "    login $SURGE_LOGIN" >> ~/.netrc
             echo "    password $SURGE_TOKEN" >> ~/.netrc
             git config --global user.email "gh-pages@localhost" && git config --global user.name "npm gh-pages"
-            if [ "$CI_BRANCH" != "master" ]; then surge-review -p styleguide || true; fi
+            if [ "$CI_BRANCH" != "master" ]; then npm run ci:update-pull-request-with-styleguide || true; fi
 
       # https://circleci.com/docs/2.0/artifacts/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,12 @@ jobs:
             git config --global user.email "gh-pages@localhost" && git config --global user.name "npm gh-pages"
             if [ "$CI_BRANCH" != "master" ]; then npm run ci:update-pull-request-with-styleguide || true; fi
 
+      # cut a release
+      - run:
+          name: release
+          command: |
+            node scripts/ci-post-test.js
+
       # https://circleci.com/docs/2.0/artifacts/
       - store_artifacts:
           path: snaps/run

--- a/package-lock.json
+++ b/package-lock.json
@@ -22767,9 +22767,9 @@
       "dev": true
     },
     "surge-review": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/surge-review/-/surge-review-1.1.0.tgz",
-      "integrity": "sha512-zLj3F51Rv2504yJogwOEanO5wdr15zkoDwO7v64zGoPeXqsmJ30ZE8+Cfg6X4sqmylNp7yGZnKwAPQ1Ecnfwog==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/surge-review/-/surge-review-1.1.1.tgz",
+      "integrity": "sha512-XfmchUcO4hGpx97GJ3CI19VY9/JiwnLTVeEwb2iV2I3cYZFewdXWYaDDdSAdJMv8vGXssbXItAPxe5sXQZ0k7g==",
       "dev": true,
       "requires": {
         "github": "9.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22767,9 +22767,9 @@
       "dev": true
     },
     "surge-review": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/surge-review/-/surge-review-1.0.2.tgz",
-      "integrity": "sha1-r5/nwCPTZtfVtd2fFrmteTOnrPY=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/surge-review/-/surge-review-1.1.0.tgz",
+      "integrity": "sha512-zLj3F51Rv2504yJogwOEanO5wdr15zkoDwO7v64zGoPeXqsmJ30ZE8+Cfg6X4sqmylNp7yGZnKwAPQ1Ecnfwog==",
       "dev": true,
       "requires": {
         "github": "9.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,6 +1943,15 @@
         }
       }
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -3636,6 +3645,13 @@
         "cssom": "0.3.2"
       }
     },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true,
+      "optional": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3644,6 +3660,12 @@
       "requires": {
         "array-find-index": "1.0.2"
       }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
     },
     "cyclist": {
       "version": "0.2.2",
@@ -4389,6 +4411,23 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
       "dev": true
+    },
+    "du": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/du/-/du-0.1.0.tgz",
+      "integrity": "sha1-8m40CgnHvFtv1pr2263qYPqMb00=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        }
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -5455,6 +5494,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
     "fast-deep-equal": {
@@ -6781,6 +6826,40 @@
         }
       }
     },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+      "integrity": "sha1-GMiR2wG3gqdKe/+Tag8kmXdBx6s=",
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7648,6 +7727,12 @@
         }
       }
     },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -7968,6 +8053,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-domain": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/is-domain/-/is-domain-0.0.1.tgz",
+      "integrity": "sha1-f/sojVzO1rB8Ty35HJvpFTURNI4=",
       "dev": true
     },
     "is-dotfile": {
@@ -10587,6 +10678,12 @@
       "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
       "dev": true
     },
+    "moniker": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
+      "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10636,6 +10733,12 @@
       "dev": true,
       "optional": true
     },
+    "natives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10650,6 +10753,12 @@
       "requires": {
         "xml-char-classes": "1.0.0"
       }
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -15777,6 +15886,12 @@
         "find-up": "1.1.2"
       }
     },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
     "pleeease-filters": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
@@ -17730,6 +17845,19 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+      "dev": true,
+      "requires": {
+        "pkginfo": "0.4.1",
+        "read": "1.0.5",
+        "revalidator": "0.1.8",
+        "utile": "0.2.1",
+        "winston": "0.8.3"
+      }
     },
     "prop-types": {
       "version": "15.6.0",
@@ -20407,6 +20535,15 @@
         "object-assign": "4.1.1"
       }
     },
+    "read": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+      "integrity": "sha1-AHo9FpR4qnEKSRcn5FPv+5LnYgM=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -20977,6 +21114,12 @@
       "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
+    },
     "rgb": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
@@ -21072,6 +21215,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
       "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
+      "dev": true
+    },
+    "run-waterfall": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.3.tgz",
+      "integrity": "sha1-2W/A9TYby9vUOFKdyKS0L8Z2ESM=",
       "dev": true
     },
     "rw": {
@@ -21866,6 +22015,12 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
     "standard": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
@@ -22396,6 +22551,249 @@
         "has-flag": "1.0.0"
       }
     },
+    "surge": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/surge/-/surge-0.19.0.tgz",
+      "integrity": "sha1-rkMN8PKDK6JKo3m3dmWG/mi3I5w=",
+      "dev": true,
+      "requires": {
+        "du": "0.1.0",
+        "fstream-ignore": "1.0.2",
+        "is-domain": "0.0.1",
+        "minimist": "1.1.1",
+        "moniker": "0.1.2",
+        "netrc": "0.1.4",
+        "progress": "1.1.8",
+        "prompt": "0.2.14",
+        "read": "1.0.5",
+        "request": "2.40.0",
+        "split": "0.3.1",
+        "surge-ignore": "0.2.0",
+        "tar": "1.0.0",
+        "tar.gz": "0.1.1",
+        "url-parse-as-address": "1.0.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+          "dev": true,
+          "optional": true
+        },
+        "boom": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+          "dev": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "dev": true,
+          "optional": true
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.9.2",
+            "combined-stream": "0.0.7",
+            "mime": "1.2.11"
+          }
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "0.4.2",
+            "cryptiles": "0.2.2",
+            "hoek": "0.9.1",
+            "sntp": "0.2.4"
+          }
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+          "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+          "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+          "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.40.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+          "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.5.0",
+            "forever-agent": "0.5.2",
+            "form-data": "0.1.4",
+            "hawk": "1.1.1",
+            "http-signature": "0.10.1",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "1.0.2",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.3.0",
+            "qs": "1.0.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "split": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.1.tgz",
+          "integrity": "sha1-zrzxQr9hu7ZLFBYo5ttIKikUZUw=",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        }
+      }
+    },
+    "surge-ignore": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/surge-ignore/-/surge-ignore-0.2.0.tgz",
+      "integrity": "sha1-Wn+KIKcRiM+edaLP6OsYLekNrzs=",
+      "dev": true
+    },
+    "surge-review": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/surge-review/-/surge-review-1.0.2.tgz",
+      "integrity": "sha1-r5/nwCPTZtfVtd2fFrmteTOnrPY=",
+      "dev": true,
+      "requires": {
+        "github": "9.3.1",
+        "lodash": "4.17.4",
+        "minimist": "1.2.0",
+        "perish": "1.0.1",
+        "run-waterfall": "1.1.3",
+        "surge": "0.19.0"
+      },
+      "dependencies": {
+        "github": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/github/-/github-9.3.1.tgz",
+          "integrity": "sha512-LvVb6iR8/7bqYgj0VeAtqys0t427jwIBkv/+or/ssypfIk5R1fnz4aeIEv4udPw6VFoH6vL4gi+foBoD5aazXg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "0.0.7",
+            "https-proxy-agent": "1.0.0",
+            "mime": "1.2.11",
+            "netrc": "0.1.4"
+          }
+        }
+      }
+    },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
@@ -22721,6 +23119,17 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "tar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
+      "integrity": "sha1-NmNtduiuErS8EalArGBrXKil/h8=",
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
     "tar-fs": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
@@ -22742,6 +23151,60 @@
         "end-of-stream": "1.4.0",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
+      }
+    },
+    "tar.gz": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-0.1.1.tgz",
+      "integrity": "sha1-6RTOI7L9xidXX72zSFpbIo7VmUc=",
+      "dev": true,
+      "requires": {
+        "commander": "1.1.1",
+        "fstream": "0.1.31",
+        "tar": "0.1.20"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
+          "dev": true,
+          "requires": {
+            "keypress": "0.1.0"
+          }
+        },
+        "fstream": {
+          "version": "0.1.31",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+          "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "3.0.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true,
+          "requires": {
+            "natives": "1.1.1"
+          }
+        },
+        "tar": {
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+          "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "0.1.31",
+            "inherits": "2.0.3"
+          }
+        }
       }
     },
     "term-size": {
@@ -23467,6 +23930,12 @@
         }
       }
     },
+    "url-parse-as-address": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz",
+      "integrity": "sha1-+4CQGIPzOLPL7TU49fqiatr38uc=",
+      "dev": true
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -23510,6 +23979,28 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
+    },
+    "utile": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "deep-equal": "1.0.1",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "0.4.2",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
+      }
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -24835,6 +25326,41 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
+    },
+    "winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "colors": "0.6.2",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "snapjerk": "^0.2.15",
     "standard": "^10.0.3",
     "style-loader": "^0.18.2",
-    "surge-review": "^1.0.2",
+    "surge-review": "^1.1.0",
     "url": "^0.11.0",
     "webpack": "3.5.6"
   },
@@ -80,7 +80,7 @@
     "secure": "nsp check",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "prestyleguide:build": "node scripts/prestyleguide",
-    "ci:update-pull-request-with-styleguide": "surge-review -p styleguide",
+    "ci:update-pull-request-with-styleguide": "surge-review --publish-dir styleguide --pull-request $CIRCLE_PULL_REQUEST",
     "styleguide:build": "styleguidist build",
     "start": "node scripts/start",
     "precommit": "run-p lint test check-vulnerablities",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "snapjerk": "^0.2.15",
     "standard": "^10.0.3",
     "style-loader": "^0.18.2",
-    "surge-review": "^1.1.0",
+    "surge-review": "^1.1.1",
     "url": "^0.11.0",
     "webpack": "3.5.6"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "snapjerk": "^0.2.15",
     "standard": "^10.0.3",
     "style-loader": "^0.18.2",
+    "surge-review": "^1.0.2",
     "url": "^0.11.0",
     "webpack": "3.5.6"
   },
@@ -79,6 +80,7 @@
     "secure": "nsp check",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "prestyleguide:build": "node scripts/prestyleguide",
+    "ci:update-pull-request-with-styleguide": "surge-review -p styleguide",
     "styleguide:build": "styleguidist build",
     "start": "node scripts/start",
     "precommit": "run-p lint test check-vulnerablities",


### PR DESCRIPTION
# problem statement

- we used to use codeship, now we use circleci, therefore:
  - we dont get updates from @wa11-e w/ static site copies on PR commits
  - we dont cut releases automatically via semantic release

# solution

- complete the transition to circleci

# notes

- circleci gives us the docker-engine fo' free!  codeship didnt.
- you should have access to the circleci builds by simply being a member of the tripwire organization on github.  make sure you log on to circle w/ you public github handle, if it prompts you