### PR TITLE
fix(pagination): Style updates to paginaton for Outline

### DIFF
--- a/src/styles/components/pagination-control.css
+++ b/src/styles/components/pagination-control.css
@@ -35,6 +35,8 @@ input[type=number]::-webkit-outer-spin-button {
   padding: 0px;
   font-size: 28px;
   max-height: var(--paginationHeight);
+  overflow: hidden;
+  position: relative;
 }
 
 .pagination__button:hover{
@@ -44,6 +46,10 @@ input[type=number]::-webkit-outer-spin-button {
 
 .pagination__button:active{
   color: var(--primaryBlue);
+}
+
+.pagination__button:focus{
+  z-index: 1;
 }
 
 .pagination__prev {
@@ -97,8 +103,4 @@ input[type=number]::-webkit-outer-spin-button {
   color: var(--disabledColor);
   cursor: not-allowed;
   background-color: var(--paginationBackgroundColor);
-}
-
-.pagination_disabled:focus {
-  outline: 0;
 }


### PR DESCRIPTION
# problem statement
1) Outline had a gap between bottom border and outline.
2) Left outline side was hidden by next button.

# solution
1) Needed to set overflow:hidden because font-size is 28px and max-height is 30px. It appears that outline is based on content of a container and not only container height.
2) I set position to relative and then set the z-index of button:focus to 1 (all others are auto).

Fixes #161 
