### PR TITLE
feat(namespacing): Namespace Native Octagon Components to avoid collisions

### DIFF
--- a/src/components/native/LargeCard/LargeCard.jsx
+++ b/src/components/native/LargeCard/LargeCard.jsx
@@ -18,7 +18,7 @@ class LargeCard extends React.Component {
     return (
       <Flexbox
         {...externalAttributes}
-        className={`large_card is-fullview-open-${this.props.showCard} ${this.props.className}`}
+        className={`octagon large_card is-fullview-open-${this.props.showCard} ${this.props.className}`}
         style={this.props.style}>
         <Flexbox
           flexDirection='row'

--- a/src/styles/components/large-card.css
+++ b/src/styles/components/large-card.css
@@ -3,7 +3,7 @@
 .text-large{
   font-size: 20px !important;
 }
-.large_card {
+.octagon.large_card {
   background: var(--formBackgroundColor);
   left: -10000px;
   min-height: 100%;
@@ -35,7 +35,7 @@
 .framed{
   margin: 10px 20px 10px 20px;
 }
-.large_card__container {
+.octagon .large_card__container {
   background: white;
   clear: fix;
   min-height: 94%;


### PR DESCRIPTION
# problem statement

We could have style collisions if we don't properly namespace.

# solution

namespace Native Octagon components with .octagon.