### PR TITLE
docs(contributing.md): Added Basic Acceptance Criteria (and some cleanup)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,9 @@
 
 this will launch the Styleguide. all of you changes to files are hot-reloaded. if you want to ship a production version your will need to test and build octagon.
 
-### production build
-
-* **build octagon** `npm build`
-  * this will create the lib bundle which will contain production build
-* **build styleguide** 'npm run styleguide:build'
-  * this will create the Styleguide to be used for testing
-* **test octagon** 
-  * both automated and manual tests ([see testing info](#step-4-test))
-* **make sure your component meets the [basic acceptance criteria](#basic-acceptance-criteria)**
-
 ### building components
 
-when building components, please follow our [Architecture Decisions](github.com/Tripwire/octagon/blob/master/doc/architecture/decisions)
+when building components, please follow our [Architecture Decisions](github.com/Tripwire/octagon/blob/master/doc/architecture/decisions). each component should include an accompanying example in a markdown file. 
 
 #### react-based functional stateless components
 octagon components are considered view-layer components and should generally be functional stateless components (see [ADR002](https://github.com/Tripwire/octagon/blob/master/doc/architecture/decisions/0002-components-shall-be-stateless-by-default.md)).
@@ -82,6 +72,18 @@ native octagon components use [cssnext](http://cssnext.io) and should follow [BE
 SUIR octagon components use LESS for styling. more information can be found on [Semantic UI's themeing page](https://semantic-ui.com/usage/theming.html). to theme SUIR components, navigate to your theme folder and add your styles in the to the component's: `.variables` and `.overides` files.
 (e.g. button.variables & button.overrides)
 
+### build for production
+
+- **build octagon** `npm run build`
+  - this will create the lib bundle which will contain production build
+  - this can be ingested by applications to use Octagon components
+- **build styleguide** `npm run styleguide:build`
+  - this will create the Styleguide folder and run Styleguidist
+  - note: this build is what is currently used for testing
+- **test octagon** 
+  - both automated and manual tests ([see testing info](#step-4-test))
+- **make sure your component meets the [acceptance criteria](#acceptance-criteria)**
+
 ## code of conduct
 
 the code of conduct (coc) explains the *bare minimum* behavior
@@ -129,14 +131,14 @@ commits should be small, targetted, and focused.  unfocused changes need to be s
 
 ### step 4: test
 
-* run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
-* run `npm test` to use our tests against your changes including webjerk image diffing
-* **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
+- run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
+- run `npm test` to use our tests against your changes including webjerk image diffing
+- **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
 > if you approve of the changes Snapjerk displays you need will to update the reference set:
-> * new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
-> * new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
-> * removed images: simplying remove the images from your reference set
-* manually test against modern browsers (Chrome evergreen, FF evergreen, & Edge)
+> - new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
+> - new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
+> - removed images: simplying remove the images from your reference set
+- manually test against modern browsers (Chrome evergreen, FF evergreen, & Edge)
 
 ### step 5: push
 
@@ -229,7 +231,7 @@ after you push new changes to your branch, you need to get
 approval for these new changes again, even if github shows "approved"
 because the reviewers have hit the buttons before.
 
-### Merge Checklist
+### acceptance criteria
 
 1. component has been reviewed by at least one technical project member
 1. component has been reviewed by UX team member

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ this will launch the Styleguide. all of you changes to files are hot-reloaded. i
 
 ### building components
 
+when building components, please follow our [Architecture Decisions](github.com/Tripwire/octagon/blob/master/doc/architecture/decisions)
+
 #### react-based functional stateless components
 octagon components are considered view-layer components and should generally be functional stateless components (see [ADR002](https://github.com/Tripwire/octagon/blob/master/doc/architecture/decisions/0002-components-shall-be-stateless-by-default.md)).
 - How to handle state is decided by the app (e.g. dealing with page number errors or and actual page number)
@@ -130,11 +132,11 @@ commits should be small, targetted, and focused.  unfocused changes need to be s
 * run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
 * run `npm test` to use our tests against your changes including webjerk image diffing
 * **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
-> if you approve of the changes Snapjerk displays you need will to update the refset:
+> if you approve of the changes Snapjerk displays you need will to update the reference set:
 > * new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
 > * new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
 > * removed images: simplying remove the images from your reference set
-* manually test against modern browsers
+* manually test against modern browsers (Chrome evergreen, FF evergreen, & Edge)
 
 ### step 5: push
 
@@ -227,12 +229,10 @@ after you push new changes to your branch, you need to get
 approval for these new changes again, even if github shows "approved"
 because the reviewers have hit the buttons before.
 
+### Merge Checklist
 
-## basic acceptance criteria
-1. component has been [reviewed](#pull-request-approvals) by at least one developer
-1. component has been reviewed by UX
-1. component passes all [tests](#testing) automated and manual
+1. component has been reviewed by at least one technical project member
+1. component has been reviewed by UX team member
+1. component passes all [tests](#step-4-test) (automated and manual)
 1. component has sufficient examples to prove prove handling of various states
- * including a simple dummy app interacting with component api
 1. component includes `data-hooks` for QA testing
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,14 @@ this will launch the Styleguide. all of you changes to files are hot-reloaded. i
 
 ### production build
 
-- **build octagon** `npm build`
--- this will create the lib bundle which will contain production build
-- **build styleguide** 'npm run styleguide:build'
--- this will create the Styleguide to be used for testing
-- **test octagon** `npm test`
--- tests will likely initially fail if you have created a new component or updated a component. this is because we using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.
--- if you approve of the changes Snapjerk displaysyou need to update the refset:
---- new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
---- new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
---- removed images: simplying remove the images from your reference set
+* **build octagon** `npm build`
+ * this will create the lib bundle which will contain production build
+* **build styleguide** 'npm run styleguide:build'
+ * this will create the Styleguide to be used for testing
+* **test octagon** `npm test`
+ * run our automated tests `npm t` including image-diffing 
+ * manually test against modern browsers
+* make sure your component meets [basic acceptance criteria](#basic-acceptance-criteria)
 
 ### building components
 
@@ -209,8 +207,8 @@ your name on it. congratulations and thanks for your contribution!
 
 ### pull request approvals
 
-a pull request is approved either by saying "+1" or a thumbs up emoji.  if the author
-has merge access, he/she may merge after getting collaborator approval.  otherwise,
+a pull request is approved either by saying "+1" or a thumbs up emoji. if the author
+has merge access, he/she may merge after getting collaborator approval. otherwise,
 the collaborator should recognize the case where the change author does not have
 merge access, and should merge on behalf of the author.
 
@@ -223,7 +221,30 @@ after you push new changes to your branch, you need to get
 approval for these new changes again, even if github shows "approved"
 because the reviewers have hit the buttons before.
 
-### ci testing
+## testing
 
-every pull request needs to be tested.  ci tests are automated and require no extra
-effort on behalf of the author.
+every component or issue must be tested before being pushed to github and subsequently merged after [PR approval](#pull-request-approvals).
+
+### local testing
+
+* run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
+* run `npm test` to use our tests against your changes including webjerk image diffing
+* **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
+> if you approve of the changes Snapjerk displays you need will to update the refset:
+> * new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
+> * new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
+> * removed images: simplying remove the images from your reference set
+
+
+### automated testing 
+*  ci tests are automated (using circleci) trigger on each push to github and require no extra effort on behalf of the author.
+
+
+## basic acceptance criteria
+1. component has been [reviewed](#pull-request-approvals) by at least one developer
+1. component has been reviewd by UX
+1. component passes all [tests](#testing) automated and manual
+1. component has sufficient examples to prove prove handling of various states
+ * including a simple dummy app interacting with component api
+1. component includes `data-hooks` for QA testing
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,12 @@ this will launch the Styleguide. all of you changes to files are hot-reloaded. i
 ### production build
 
 * **build octagon** `npm build`
- * this will create the lib bundle which will contain production build
+  * this will create the lib bundle which will contain production build
 * **build styleguide** 'npm run styleguide:build'
- * this will create the Styleguide to be used for testing
-* **test octagon** `npm test`
- * run our automated tests `npm t` including image-diffing 
- * manually test against modern browsers
-* make sure your component meets [basic acceptance criteria](#basic-acceptance-criteria)
+  * this will create the Styleguide to be used for testing
+* **test octagon** 
+  * both automated and manual tests ([see testing info](#step-4-test))
+* **make sure your component meets the [basic acceptance criteria](#basic-acceptance-criteria)**
 
 ### building components
 
@@ -128,7 +127,14 @@ commits should be small, targetted, and focused.  unfocused changes need to be s
 
 ### step 4: test
 
-bug fixes and features **should come with tests**.  ideally, screenshots and snapshots are included for visual targetted changes.
+* run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
+* run `npm test` to use our tests against your changes including webjerk image diffing
+* **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
+> if you approve of the changes Snapjerk displays you need will to update the refset:
+> * new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
+> * new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
+> * removed images: simplying remove the images from your reference set
+* manually test against modern browsers
 
 ### step 5: push
 
@@ -221,28 +227,10 @@ after you push new changes to your branch, you need to get
 approval for these new changes again, even if github shows "approved"
 because the reviewers have hit the buttons before.
 
-## testing
-
-every component or issue must be tested before being pushed to github and subsequently merged after [PR approval](#pull-request-approvals).
-
-### local testing
-
-* run Standard linter to ensure code formatting is correct (or set up your editor to automate this)
-* run `npm test` to use our tests against your changes including webjerk image diffing
-* **tests will likely initially fail if you have created or updated a component. this is because we are using [Snapjerk](https://www.npmjs.com/package/snapjerk) image-diffing software.**
-> if you approve of the changes Snapjerk displays you need will to update the refset:
-> * new images: set WEBJERK_ALLOW_NEW_IMAGES=1 in your env
-> * new changed images: set WEBJERK_APPROVE_CHANGES=1 in your env
-> * removed images: simplying remove the images from your reference set
-
-
-### automated testing 
-*  ci tests are automated (using circleci) trigger on each push to github and require no extra effort on behalf of the author.
-
 
 ## basic acceptance criteria
 1. component has been [reviewed](#pull-request-approvals) by at least one developer
-1. component has been reviewd by UX
+1. component has been reviewed by UX
 1. component passes all [tests](#testing) automated and manual
 1. component has sufficient examples to prove prove handling of various states
  * including a simple dummy app interacting with component api


### PR DESCRIPTION
per confluence task as a result of Pagination Retro:
"will create a "done is done" list in the CONTRIBUTING.md that specifies all of the required attributes of an Octagon UI component (data hooks, cross-browser testing, webjerk screen shots, usage example, etc.) by calendar icon16 Mar 2018"

# problem statement

We need Basic Acceptance Criteria in Contributing.md
Also, some mistakes in the current Contrib (bad markdown, spelling, grammar)

# solution

Add it!

- updated contrib w/ basic acceptance criteria
- moved testing to it's own section
- clean up - misspellings, grammar, markdown fixes, etc.
