### PR TITLE
fix(LeftNav): remove evil styles, allow class extension

### DIFF
--- a/src/components/native/LeftNav/LeftNav.jsx
+++ b/src/components/native/LeftNav/LeftNav.jsx
@@ -2,10 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import LeftNavMenuItem from './LeftNavMenuItem'
 import '../../../styles/components/left-nav.css'
+import classnames from 'classnames'
 
 const LeftNav = (props) => {
   return (
-    <nav className='octagon nav__left ' {...props}>
+    <nav {...props} className={classnames(props.className, 'octagon nav__left')}>
       {props.children}
     </nav>
   )

--- a/src/styles/components/left-nav.css
+++ b/src/styles/components/left-nav.css
@@ -2,12 +2,8 @@
 .octagon.nav__left {
   background: color(var(--cloudburst));
   color: var(--white);
-  min-height: 100vh;
-  height: 100%;
-  left: 0;
   list-style: none;
   position: relative;
-  top: 0px;
   width: 65px;
   & .nav_border--active {
     border-left: 4px solid var(--white);


### PR DESCRIPTION
# problem statement

- `LeftNav` styles assumed too much about their usage context `height`

# solution

- make the styles of this component extensible. remove overly contextual assumptions

# discussion

- we just did a `LeftNav` PR.  sorry i missed this in that one!  i've been doing a bottom up design, which meant i hadn't actually plugged this component into the app properly until moments ago
