### PR TITLE
feat/fast-dev-watch-mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,29 @@
-# contributing to octagon
+# contributing
 
-## development (adding components)
+## development
 
-### starting the environment
+`octagon` offers two mechanisms to support development:
+
+- `npm run dev` - watch the source code & rebuild the library onchange
+  - this mode is **strongly** recommended when developing octagon and linking it into a consuming project
+    - to develop this library in real-time whilst using it in another project:
+      - run `npm link` in this project's source
+      - run `npm link react-octagon` in the consuming project's source
+
+- `npm start` - launch the interactive styleguide.  see more below.
+### styleguide
+
 - run `npm start`
 - open the URL (probably `localhost:6060`) to play w/ components as you develop them
 
-this will launch the Styleguide. all of you changes to files are hot-reloaded. if you want to ship a production version your will need to test and build octagon.
+this will launch the styleguide. all of you changes to files are hot-reloaded. if you want to ship a production version your will need to test and build octagon.
 
 ### building components
 
 when building components, please follow our [Architecture Decisions](github.com/Tripwire/octagon/blob/master/doc/architecture/decisions). each component should include an accompanying example in a markdown file.
 
 #### react-based functional stateless components
+
 octagon components are considered view-layer components and should generally be functional stateless components (see [ADR002](https://github.com/Tripwire/octagon/blob/master/doc/architecture/decisions/0002-components-shall-be-stateless-by-default.md)).
 - How to handle state is decided by the app (e.g. dealing with page number errors or and actual page number)
 - Positioning of the component will be decided by the app (e.g. 4px padding on the right and left)
@@ -37,7 +48,7 @@ octagon components are considered view-layer components and should generally be 
 
 #### native octagon component styles
 
-native octagon components use [cssnext](http://cssnext.io) and should follow [BEM CSS Standards](https://en.bem.info/methodology/css/). the styles belows show a block, element, and modifier.
+native octagon components use [cssnext](http://cssnext.io) and should follow [BEM CSS Standards](https://en.bem.info/methodology/css/). the styles below show a `block`, `element`, and `modifier`.
 
 ```css
 .pagination {
@@ -69,7 +80,7 @@ native octagon components use [cssnext](http://cssnext.io) and should follow [BE
 
 #### SUIR octagon component styles
 
-SUIR octagon components use LESS for styling. more information can be found on [Semantic UI's themeing page](https://semantic-ui.com/usage/theming.html). to theme SUIR components, navigate to your theme folder and add your styles in the to the component's: `.variables` and `.overides` files.
+SUIR octagon components use LESS for styling. more information can be found on [Semantic UI's themeing page](https://semantic-ui.com/usage/theming.html). to theme SUIR components, navigate to your theme folder, `src/semantic-ui-theme`, and add your styles in the to the component's: `.variables` and `.overides` files.
 (e.g. button.variables & button.overrides)
 
 ### build for production

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "semantic-ui-react": "^0.79.1"
   },
   "scripts": {
+    "dev": "run-p watch:*",
     "build": "node scripts/build",
     "lint": "standard",
     "test": "DEBUG=webjerk* snapjerk",
@@ -66,6 +67,9 @@
     "start": "node scripts/start",
     "precommit": "run-p lint test",
     "semantic-release": "semantic-release",
+    "watch:css": "node scripts/watch css",
+    "watch:js": "node scripts/watch js",
+    "watch:sui": "node scripts/watch sui",
     "write-styleguide-sections": "node scripts/write-styleguide-sections"
   },
   "standard": {

--- a/scripts/builder.js
+++ b/scripts/builder.js
@@ -87,7 +87,13 @@ module.exports = {
     const outputDir = path.join(this.componentDist)
     const inputDir = path.join(this.projectRoot, 'src/**/*.css')
     const cmd = this.getBin('postcss')
-    const args = [inputDir, '-d', outputDir, '-c', this.postCssConfig, '--base', 'src']
+    const args = [
+      inputDir,
+      '-d', outputDir,
+      '-c', this.postCssConfig,
+      '--base', 'src'
+    ]
+    if (opts.watch) args.push('--watch')
     await fs.mkdirp(this.componentDist)
     return execa(cmd, args, { cwd: this.projectRoot, stdio: 'inherit' })
   },
@@ -161,18 +167,7 @@ module.exports = {
       this.styleguideWriteSections(),
       this.build()
     ])
-    var compileChain = Promise.resolve() // poor mains queueing
-    const recompileCss = debounce(path => {
-      console.log(`${path} changed`)
-      compileChain = compileChain.then(() => this.buildSemantic())
-    }, 1000)
-    const watcher = chokidar.watch(this.twSuiThemeSrcPath)
-    watcher.on('ready', () => {
-      return watcher
-      .on('add', recompileCss)
-      .on('change', recompileCss)
-      .on('unlink', recompileCss)
-    })
+    const watcher = this.watchSui()
     try {
       await execa(
         'npx',
@@ -217,5 +212,31 @@ module.exports = {
       path.resolve(this.projectRoot, '.octagon-native-sections.json'),
       JSON.stringify(sections, null, 2)
     )
+  },
+  watchCss () {
+    return this.octagonComponentCss({ watch: true })
+  },
+  watchJs () {
+    return this.octagonComponentJs({ watch: true })
+  },
+  watchSui () {
+    var compileChain = Promise.resolve() // poor mans queueing
+    const recompileCss = debounce(async path => {
+      console.log(`${path} changed`)
+      await compileChain
+      console.time('semantic-ui rebuilt in')
+      compileChain = this.buildSemantic()
+      await compileChain
+      console.timeEnd('semantic-ui rebuilt in')
+    }, 1000)
+    recompileCss()
+    const watcher = chokidar.watch(this.twSuiThemeSrcPath)
+    watcher.on('ready', () => {
+      return watcher
+        .on('add', recompileCss)
+        .on('change', recompileCss)
+        .on('unlink', recompileCss)
+    })
+    return watcher
   }
 }

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -1,0 +1,16 @@
+require('perish')
+const builder = require('./builder')
+const task = process.argv[2]
+
+void (async function watch () {
+  switch (task) {
+    case 'css':
+      return builder.watchCss()
+    case 'js':
+      return builder.watchJs()
+    case 'sui':
+      return builder.watchSui()
+    default:
+      throw new Error(`no task named: ${task || '[no task provided]'}`)
+  }
+}())


### PR DESCRIPTION
# problem statement

- @ggascoigne mentioned some historic woes on using octagon in dev mode whilst using it in his app

whilst linking and on-change simply running `[yarn|npm] build` _works_, it's not RAPIDO 💨 

# solution

- enable a `watch` mode for quick incremental builds
  - rather than doing a blanket file system watch and rebuilding all of the things, instead, use individual watchers for each part of the lib (react components, react component styles, and the sui theme)
  - builds are suuuuper fast for react & components css changes (ms level), whilst building the full sui theme takes ~2-3 seconds 

![untitled mov](https://user-images.githubusercontent.com/1003261/39654681-bb85d3e8-4faa-11e8-9a18-9925f98cec66.gif)
