### PR TITLE
feat(LoginPane): enable unstable thirdPartyAuth prop

### DIFF
--- a/src/components/unstable/Layout/Layout.examples.md
+++ b/src/components/unstable/Layout/Layout.examples.md
@@ -1,7 +1,11 @@
 ### Empty layout:
 
 ```js
-<Layout className='hide-in-test' logo={<h1 style={{color: 'white'}}>LOGO</h1>} />
+<Layout
+  className='hide-in-test'
+  logo={<h1 style={{color: 'white'}}>LOGO</h1>}
+  navItems={[]}
+/>
 ```
 
 ### Populated Layout:

--- a/src/components/unstable/LoginPane/LoginPane.css
+++ b/src/components/unstable/LoginPane/LoginPane.css
@@ -22,6 +22,13 @@
   text-align: center;
 }
 
+.login__container.login__container--third-party-auth {
+  grid-template-areas:
+    "logo"
+    "third-party-content"
+    "footer";
+}
+
 .login__container--compact-y {
   grid-row-gap: 0;
 }
@@ -48,4 +55,8 @@
 
 .login__footer {
   grid-area: footer;
+}
+
+.login__third-party-content {
+  grid-area: third-party-content;
 }

--- a/src/components/unstable/LoginPane/LoginPane.examples.md
+++ b/src/components/unstable/LoginPane/LoginPane.examples.md
@@ -1,19 +1,18 @@
-### Login Pane Basic
+#### Login Pane Basic
 
 ```js
 const { BasicLoginPane } = require('./LoginPaneExamples');
 <BasicLoginPane />
 ```
 
-### Login Pane CompactY
+#### Login Pane CompactY
 
 ```js
 const { BasicLoginPane } = require('./LoginPaneExamples');
 <BasicLoginPane compactY />
 ```
 
-
-##### LoginPane full
+#### LoginPane full
 
 ```js
 const { Button, Input } = require('semantic-ui-react');
@@ -65,4 +64,29 @@ const { Button, Input } = require('semantic-ui-react');
     for more information.
   </LoginPane.Footer>
 </LoginPane>
+```
+
+#### Login Pane - 3rd Party Auth
+
+Remove the standard authorization form, allow for a 3rd party auth widget.
+Render all 3rd party content into `<LoginPane.ThirdPartyContent />`.
+
+```js
+  <LoginPane className='hide-in-test' thirdPartyAuth>
+    <LoginPane.Logo>
+      <h1 style={{
+        padding: '20px',
+        background: 'darkslategray',
+        color: 'white'
+      }}>
+        LOGO
+      </h1>
+    </LoginPane.Logo>
+    <LoginPane.ThirdPartyContent>
+      <h4>Add 3rd party auth widget here</h4>
+    </LoginPane.ThirdPartyContent>
+    <LoginPane.Footer>
+      <footer>FOOTER</footer>
+    </LoginPane.Footer>
+  </LoginPane>
 ```

--- a/src/components/unstable/LoginPane/LoginPane.jsx
+++ b/src/components/unstable/LoginPane/LoginPane.jsx
@@ -6,11 +6,18 @@ import xor from 'lodash/xor'
 
 export default class LoginPane extends PureComponent {
   render () {
-    const { children, className, compactY, ...rest } = this.props
+    const {
+      children,
+      className,
+      compactY,
+      thirdPartyAuth,
+      ...rest
+    } = this.props
     const classNames = cx(
       className,
       'login__container',
-      compactY ? 'login__container--compact-y' : null
+      compactY ? 'login__container--compact-y' : null,
+      thirdPartyAuth ? 'login__container--third-party-auth' : null
     )
     return (
       <form {...rest} className={classNames}>
@@ -21,6 +28,7 @@ export default class LoginPane extends PureComponent {
 }
 LoginPane.propTypes = {
   compactY: PropTypes.bool,
+  thirdPartyAuth: PropTypes.bool,
   children: function (props, propName, componentName) {
     var childrenTypes = props[propName].map(el => el.type.name)
     var allowedTypes = [
@@ -30,6 +38,13 @@ LoginPane.propTypes = {
       LoginPane.Submit.name,
       LoginPane.Footer.name
     ]
+    if (props.thirdPartyAuth) {
+      allowedTypes = [
+        LoginPane.Logo.name,
+        LoginPane.ThirdPartyContent.name,
+        LoginPane.Footer.name
+      ]
+    }
 
     // Only accept a single child, of the appropriate type
     if (xor(childrenTypes, allowedTypes).length) {
@@ -44,6 +59,15 @@ LoginPane.propTypes = {
       )
     }
   }
+}
+
+LoginPane.Footer = function LoginFooter (props) {
+  const { className, children, ...rest } = props
+  return (
+    <footer {...rest} className={cx(className, 'login__footer')}>
+      {children}
+    </footer>
+  )
 }
 
 LoginPane.Logo = function LoginLogo (props) {
@@ -82,11 +106,11 @@ LoginPane.Submit = function LoginSubmit (props) {
   )
 }
 
-LoginPane.Footer = function LoginFooter (props) {
+LoginPane.ThirdPartyContent = function ThirdPartyContent (props) {
   const { className, children, ...rest } = props
   return (
-    <footer {...rest} className={cx(className, 'login__footer')}>
+    <span {...rest} className={cx(className, 'login__third-party-content')}>
       {children}
-    </footer>
+    </span>
   )
 }

--- a/src/components/unstable/LoginPane/LoginPaneExamples.js
+++ b/src/components/unstable/LoginPane/LoginPaneExamples.js
@@ -6,11 +6,13 @@ function Basic (props) {
   return (
     <LoginPane className='hide-in-test' {...props}>
       <LoginPane.Logo>
-        <h1 style={{
-          padding: '20px',
-          background: 'darkslategray',
-          color: 'white'
-        }}>
+        <h1
+          style={{
+            padding: '20px',
+            background: 'darkslategray',
+            color: 'white'
+          }}
+        >
           LOGO
         </h1>
       </LoginPane.Logo>
@@ -21,9 +23,7 @@ function Basic (props) {
         <Input />
       </LoginPane.Password>
       <LoginPane.Submit>
-        <Button primary>
-          Login
-        </Button>
+        <Button primary>Login</Button>
       </LoginPane.Submit>
       <LoginPane.Footer>
         <footer>FOOTER</footer>


### PR DESCRIPTION
# problem statement

- some apps use libs that bring their own auth widgets

# solution

- support that use case

add `thirdPartyAuth` and friends to the `<LoginPane />` component
