### PR TITLE
fix(Button): Fix for augmented buttons so styling remains consistent.…

### DIFF
--- a/src/semantic-ui-theme/themes/tripwire/elements/button.overrides
+++ b/src/semantic-ui-theme/themes/tripwire/elements/button.overrides
@@ -8,6 +8,7 @@
   border: 2px solid @blue;
   background: @white;
   border-radius: 2px;
+  appearance: inherit;
 }
 
 .ui.buttons .button:first-child,


### PR DESCRIPTION
… In SUIR you can augment a tag with 'as' such that it is rendered in the dom. When we added type=submit to this augmented button, the default CSS of appearance: button; overwrote our styling. The solution is to set appearance: inherit

# problem statement

If you set a SUIR Button to have an href and type=submit, the styling gets wonky per #218.
TOC needed to used the SUIR augmentation feature so they can use the download attribute (that is reserved for the anchor tag => thus as='a').

https://stackoverflow.com/questions/45089966/what-are-as-props-in-semantic-ui-react-components#answer-45143938
 
# solution

The problem was that when the dom element became an anchor w/ href and type, the default styling became 'appearance: button'. Setting our default button styles to 'appearance: inherit' was that was needed to solve this.

# discussion
 Example:
```
<Button
                  positive
                  type='submit'
                  onClick={handleGenerateAndClose}
                  onBlur={handleClearState}
                  disabled={!valid || submitting}
                  data-hook={`generate-bundle-and-close-button`}
                  as='a' download
                  href={downloadUri}>Generate and Close
                </Button>
```


closes #218 