### PR TITLE
fix(ThinCard): Stop passing "expanded" prop to inner div

### DIFF
--- a/src/components/ThinCard/ThinCardDrawer.jsx
+++ b/src/components/ThinCard/ThinCardDrawer.jsx
@@ -4,10 +4,10 @@ import React from 'react'
 import { Icon } from 'semantic-ui-react'
 
 const ThinCardDrawer = props => {
-  const { children, expandGroupToggle, ...rest } = props
+  const { children, expanded, expandGroupToggle, ...rest } = props
   return (
     <div {...rest}>
-      {!props.expanded ? (
+      {!expanded ? (
         <Flexbox
           className='drawer'
           flexDirection='row'


### PR DESCRIPTION
Fixes #258

