### PR TITLE
fix(webpack): Fix importing CSS with latest webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,9 @@
     "url": "https://github.com/Tripwire/octagon.git"
   },
   "version": "0.0.0-development",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "lint-staged": {
     "linters": {
       "src/**/*.js": [


### PR DESCRIPTION

# problem statement

Webpack 4 will drop any unused imports unless they are declared to have side effects. We have to declare css files as having side effects (despite the fact that it should be obvious), or webpack will just drop it.

# solution

Declare `*.css` as having side effects in package.json

# discussion

- https://github.com/facebook/create-react-app/issues/5140

Fixes #297
