### PR TITLE
fix(bannermessage) doesn't accept text wrapped in paragraph tag.

### DIFF
--- a/src/components/BannerMessage/BannerMessageBody.jsx
+++ b/src/components/BannerMessage/BannerMessageBody.jsx
@@ -6,10 +6,11 @@ import React from 'react'
 
 const BannerMessageBody = props => {
   const { children, ...rest } = props
+  const content = typeof children === 'string' ? <p>children</p> : children
   return (
-    <p className='banner-message__body' {...rest}>
-      {children}
-    </p>
+    <div className='banner-message__body' {...rest}>
+      {content}
+    </div>
   )
 }
 


### PR DESCRIPTION
# problem statement

if dev passes text wrapped in paragraph tag React throws an error.

# solution

don't assume a naked string is passed through. body container is now div. if naked string is passed, wrap it in paragraph tag.

fixes #313 