### PR TITLE
Defect fixed for Text-box for entering page number below tables is surrounded by red border in Firefox 

### DIFF
--- a/src/styles/components/pagination-control.css
+++ b/src/styles/components/pagination-control.css
@@ -105,6 +105,9 @@
     height: 16px;
     margin: 7px var(--paginationSpaceBetweenWords);
     padding: 1px 4px;
+    &:invalid{
+      box-shadow: 0px 0px 0px var(--mainPaginationColor);
+    }
   }
 
   & .pagination__page-total {


### PR DESCRIPTION
# problem statement

Text box for entering page number below tables is surrounded by red border in Firefox

The pagination controls below the tables on the Dashboard and Settings pages seem to have a red border around them when viewed in Firefox. 
This red border does not appear when the same controls are viewed in Chrome.

