### PR TITLE
chore(testing): Automatically build styleguide before testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "dev": "run-p watch:*",
     "build": "node scripts/build",
     "lint": "standard",
+    "pretest": "run-p styleguide:build",
     "test": "cross-env DEBUG=webjerk* snapjerk",
     "prestyleguide:build": "run-p build write-styleguide-sections",
     "ci:update-pull-request-with-styleguide": "surge-review --publish-dir styleguide --pull-request $CIRCLE_PULL_REQUEST",


### PR DESCRIPTION
Since tests depend on having the styleguide rebuild, automatically
rebuild with a "pretest" command.

Closes #266
