### PR TITLE
fix(notification): update to empty notification to fix typo

### DIFF
--- a/src/components/Notification/NotificationEmpty.jsx
+++ b/src/components/Notification/NotificationEmpty.jsx
@@ -7,7 +7,7 @@ const NotificationEmpty = props => {
     <div className='empty__notification_panel' {...rest}>
       <div className='outer-circle'>
         <div className='inner-circle'>
-          <Icon className='bell outline bell_icon' size='big' />
+          <Icon name='bell outline' className='bell_icon' size='big' />
           <div className='info_text'>
             <span>No New Notifications!</span>
           </div>

--- a/src/components/Notification/NotificationEmpty.jsx
+++ b/src/components/Notification/NotificationEmpty.jsx
@@ -7,7 +7,7 @@ const NotificationEmpty = props => {
     <div className='empty__notification_panel' {...rest}>
       <div className='outer-circle'>
         <div className='inner-circle'>
-          <Icon name='bell outline bell_icon' size='big' />
+          <Icon className='bell outline bell_icon' size='big' />
           <div className='info_text'>
             <span>No New Notifications!</span>
           </div>


### PR DESCRIPTION
update to empty notification to fix typo where 'name' was used instead of 'className'

# problem statement

SUIR violation
noted in #333 "uses class bell_icon, which violates SUIR's propTypes-like-thing"

# solution

fix typo 'name' should be 'className'

fixes #333 